### PR TITLE
Fix RMSNorm reference

### DIFF
--- a/quantization_utils.py
+++ b/quantization_utils.py
@@ -1,6 +1,11 @@
 import torch
 import numpy as np
 
+
+def RMSNorm(x, eps: float = 1e-6):
+    """Compute RMS normalization used before quantization."""
+    return x * torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + eps)
+
 def activation_quant(x):
     scale = 127.0 / x.abs().max(dim=-1, keepdim=True).values.clamp_(min=1e-5)
     y = (x * scale).round().clamp_(-128, 127) / scale


### PR DESCRIPTION
## Summary
- implement RMSNorm inside `quantization_utils.py`
- run compilation checks

## Testing
- `python -m py_compile quantization_utils.py inference.py llama_model.py new-model-architecture-creation.py trainingv2.py data_loading_compatibility.py custom_gradient_checkpointing.py`
- `python - <<'PY'
import torch
from quantization_utils import activation_norm_quant
print('start')
y, scale = activation_norm_quant(torch.randn(2,3))
print('output shapes', y.shape, scale.shape)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6843307f9c588324918492d839221996