### PR TITLE
Use CLI model path for training

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python trainingv2.py --dataset <dataset_path> --model_path <model_path> --batch_
 Sample training command:
 
 ```
-python trainingv2.py --dataset /Users/user/folder/Datasets/codeDataset/data/train.jsonl --batch_size 8 --num_epochs 5000 --output_dir /Users/user/Downloads/llama_750m_finetune_tritnet-v2 --iters 10000 --max_length 4096 --learning_rate 1e-4 --grad_accum_steps 10
+python trainingv2.py --dataset /Users/user/folder/Datasets/codeDataset/data/train.jsonl --model_path /Users/user/path/to/model --batch_size 8 --num_epochs 5000 --output_dir /Users/user/Downloads/llama_750m_finetune_tritnet-v2 --iters 10000 --max_length 4096 --learning_rate 1e-4 --grad_accum_steps 10
 ```
 
 ## Dataset
@@ -106,7 +106,7 @@ The `evaluate` function in `trainingv2.py` evaluates the model on a validation s
 
 ## Saving and Loading Models
 
-The model generated from `new-model-architecture-creation.py` will be saved in the same directory where you ran the script from. When running `trainingv2.py` you will be prompted to enter the path of that model. The output directory you specify in the training command will be where the finetuned model is saved. 
+The model generated from `new-model-architecture-creation.py` will be saved in the directory where you ran the script. Provide this path using the `--model_path` argument when running `trainingv2.py`. The output directory you specify in the training command will be where the finetuned model is saved.
 
 ## Contributing
 

--- a/trainingv2.py
+++ b/trainingv2.py
@@ -197,7 +197,7 @@ def train(model, tokenizer, dataset, batch_size, num_epochs, learning_rate, iter
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Fine-tuning script.")
     parser.add_argument("--dataset", type=str, help="Path to the dataset file.")
-    parser.add_argument("--model_path", type=str, help="Path to the pre-trained model.")
+    parser.add_argument("--model_path", type=str, required=True, help="Path to the pre-trained model.")
     parser.add_argument("--batch_size", type=int, default=4, help="Batch size for training.")
     parser.add_argument("--num_epochs", type=int, default=3, help="Number of training epochs.")
     parser.add_argument("--learning_rate", type=float, default=1e-5, help="Learning rate for the optimizer.")
@@ -214,7 +214,7 @@ if __name__ == "__main__":
     file_format = args.dataset.split(".")[-1]
     dataset = preprocess_dataset(args.dataset, file_format)
 
-    model_path = input("Please enter the path to the pre-trained model you want to fine-tune: ")
+    model_path = args.model_path
 
     # Load the model configuration from the pre-trained model directory
     config = LlamaConfig.from_pretrained(model_path)


### PR DESCRIPTION
## Summary
- pull `model_path` from command line args instead of input
- document `--model_path` usage in README

## Testing
- `python trainingv2.py --dataset sample.txt --model_path dummy_model --batch_size 1 --num_epochs 1 --iters 1 --val_batches 1 --steps_per_eval 1 --steps_per_report 1 --max_length 128 --grad_accum_steps 1` *(fails: requires protobuf library)*

------
https://chatgpt.com/codex/tasks/task_e_6843309cd4948324b33403e744c19a2d