### PR TITLE
Add HBitLinear and basic quantization tests

### DIFF
--- a/h_bitlinear.py
+++ b/h_bitlinear.py
@@ -1,0 +1,25 @@
+import math
+import torch
+import torch.nn as nn
+from quantization_utils import act_quant_4bit, weight_quant
+
+class HBitLinear(nn.Linear):
+    """Linear layer with Hadamard transform for activations and 1-bit weights."""
+    def __init__(self, in_features, out_features, bias=True):
+        super().__init__(in_features, out_features, bias)
+        # Precompute Hadamard matrix for input dimension if power of two
+        if (in_features & (in_features - 1)) == 0:
+            self.register_buffer('hadamard', torch.tensor(torch.linalg.hadamard(in_features), dtype=torch.float32), persistent=False)
+        else:
+            self.hadamard = None
+        self.eps = 1e-5
+
+    def forward(self, x):
+        if self.hadamard is not None:
+            # Apply Hadamard transform
+            x = torch.matmul(x, self.hadamard) / math.sqrt(self.in_features)
+        # Quantize activations to 4-bit
+        x = act_quant_4bit(x)
+        # Quantize weights to 1-bit
+        w = weight_quant(self.weight)
+        return nn.functional.linear(x, w, self.bias)

--- a/tests/test_h_bitlinear.py
+++ b/tests/test_h_bitlinear.py
@@ -1,0 +1,13 @@
+import torch
+import unittest
+from h_bitlinear import HBitLinear
+
+class HBitLinearTest(unittest.TestCase):
+    def test_forward_shape(self):
+        layer = HBitLinear(4, 2, bias=False)
+        inp = torch.randn(3, 4)
+        out = layer(inp)
+        self.assertEqual(out.shape, (3, 2))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_quantization.py
+++ b/tests/test_quantization.py
@@ -1,0 +1,18 @@
+import torch
+import unittest
+from quantization_utils import act_quant_4bit, weight_quant
+
+class QuantizationTest(unittest.TestCase):
+    def test_activation_quant_4bit_range(self):
+        x = torch.randn(2, 4)
+        q = act_quant_4bit(x)
+        self.assertTrue(q.max() <= 7)
+        self.assertTrue(q.min() >= -8)
+
+    def test_weight_quant_1bit(self):
+        w = torch.randn(10, 5)
+        q = weight_quant(w)
+        self.assertTrue(q.unique().numel() <= 3)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `HBitLinear` module applying a Hadamard transform before quantization
- add unit tests checking quantization range and the new layer's output shape

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684334aac0d88324809b2f04ccc56a5f