### PR TITLE
Add reward utilities for QA GRPO training

### DIFF
--- a/grpo_train.py
+++ b/grpo_train.py
@@ -1,0 +1,114 @@
+import argparse
+import json
+import random
+import torch
+from transformers import AutoTokenizer
+from llama_model import LlamaModel
+from grpo import GRPOTrainer
+from reward_utils import qa_reward
+
+
+def load_dataset(path):
+    """Load a dataset of {"query":..., "answer":...}. Supports JSON and JSONL."""
+    data = []
+    if path.endswith(".jsonl"):
+        with open(path, 'r', encoding='utf-8') as f:
+            for line in f:
+                obj = json.loads(line)
+                data.append({'query': obj['query'], 'answer': obj['answer']})
+    elif path.endswith('.json'):
+        with open(path, 'r', encoding='utf-8') as f:
+            for obj in json.load(f):
+                data.append({'query': obj['query'], 'answer': obj['answer']})
+    else:
+        raise ValueError('Unsupported dataset format')
+    return data
+
+
+def reward_fn(generated: str, reference: str) -> float:
+    """F1-based reward for QA datasets."""
+    return qa_reward(generated, reference)
+
+
+def pad_sequences(seqs, pad_id):
+    max_len = max(len(s) for s in seqs)
+    tensor = torch.full((len(seqs), max_len), pad_id, dtype=torch.long)
+    lengths = torch.zeros(len(seqs), dtype=torch.long)
+    for i, s in enumerate(seqs):
+        tensor[i, :len(s)] = torch.tensor(s, dtype=torch.long)
+        lengths[i] = len(s)
+    return tensor, lengths
+
+
+def prepare_batch(samples, tokenizer, model, group_size, max_length):
+    q_tokens = [tokenizer.encode(s['query'], add_special_tokens=False) for s in samples]
+    answers = [s['answer'] for s in samples]
+    pad_id = tokenizer.pad_token_id or tokenizer.eos_token_id
+    queries, _ = pad_sequences(q_tokens, pad_id)
+
+    B = len(samples)
+    responses = []
+    lengths = []
+    rewards = []
+    for i in range(B):
+        q = q_tokens[i]
+        inp = torch.tensor([q], dtype=torch.long)
+        grp_resp = []
+        grp_len = []
+        grp_rew = []
+        for _ in range(group_size):
+            out = model.generate(inp, max_length=len(q) + max_length, do_sample=True)
+            resp = out[0, len(q):].tolist()
+            grp_resp.append(resp)
+            grp_len.append(len(resp))
+            gen_text = tokenizer.decode(resp)
+            grp_rew.append(reward_fn(gen_text, answers[i]))
+        responses.append(grp_resp)
+        lengths.append(grp_len)
+        rewards.append(grp_rew)
+
+    max_resp_len = max(max(l) for l in lengths)
+    resp_tensor = torch.full((B, group_size, max_resp_len), pad_id, dtype=torch.long)
+    len_tensor = torch.zeros(B, group_size, dtype=torch.long)
+    for b in range(B):
+        for g in range(group_size):
+            seq = responses[b][g]
+            resp_tensor[b, g, :len(seq)] = torch.tensor(seq, dtype=torch.long)
+            len_tensor[b, g] = len(seq)
+    reward_tensor = torch.tensor(rewards, dtype=torch.float)
+    return queries, resp_tensor, len_tensor, reward_tensor
+
+
+def main():
+    parser = argparse.ArgumentParser(description="GRPO training loop")
+    parser.add_argument("--dataset", type=str, required=True, help="Path to JSON or JSONL dataset")
+    parser.add_argument("--model_path", type=str, required=True, help="Directory with pretrained model")
+    parser.add_argument("--output_dir", type=str, default="grpo_model", help="Where to save the trained model")
+    parser.add_argument("--batch_size", type=int, default=1)
+    parser.add_argument("--group_size", type=int, default=2)
+    parser.add_argument("--steps", type=int, default=100)
+    parser.add_argument("--max_length", type=int, default=20)
+    parser.add_argument("--lr", type=float, default=1e-5)
+    parser.add_argument("--clip_eps", type=float, default=0.2)
+    parser.add_argument("--beta", type=float, default=0.01)
+    args = parser.parse_args()
+
+    dataset = load_dataset(args.dataset)
+    tokenizer = AutoTokenizer.from_pretrained(args.model_path)
+    model = LlamaModel.load_pretrained(args.model_path)
+    ref_model = LlamaModel.load_pretrained(args.model_path)
+    trainer = GRPOTrainer(model, ref_model, clip_eps=args.clip_eps, beta=args.beta)
+    optimizer = torch.optim.AdamW(model.parameters(), lr=args.lr)
+
+    for step in range(args.steps):
+        batch = random.sample(dataset, args.batch_size)
+        q, r, l, rew = prepare_batch(batch, tokenizer, model, args.group_size, args.max_length)
+        loss = trainer.step(q, r, l, rew, optimizer)
+        if step % 10 == 0:
+            print(f"Step {step}: loss {loss.item():.4f}")
+
+    model.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/reward_utils.py
+++ b/reward_utils.py
@@ -1,0 +1,48 @@
+import re
+from collections import Counter
+import torch
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+
+
+def _normalize(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"[^a-z0-9\s]", " ", text)
+    text = " ".join(text.split())
+    return text
+
+
+def f1_score(prediction: str, ground_truth: str) -> float:
+    pred_tokens = _normalize(prediction).split()
+    gold_tokens = _normalize(ground_truth).split()
+    common = Counter(pred_tokens) & Counter(gold_tokens)
+    num_same = sum(common.values())
+    if len(pred_tokens) == 0 or len(gold_tokens) == 0:
+        return float(pred_tokens == gold_tokens)
+    if num_same == 0:
+        return 0.0
+    precision = num_same / len(pred_tokens)
+    recall = num_same / len(gold_tokens)
+    return 2 * precision * recall / (precision + recall)
+
+
+def qa_reward(generated: str, reference: str) -> float:
+    """F1-based reward for QA tasks."""
+    return f1_score(generated, reference)
+
+
+class RewardModelScorer:
+    """Use a sequence classification model to score responses."""
+
+    def __init__(self, model_name: str):
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+        self.model = AutoModelForSequenceClassification.from_pretrained(model_name)
+        self.model.eval()
+
+    def score(self, query: str, response: str) -> float:
+        inp = self.tokenizer(query, response, return_tensors="pt")
+        with torch.no_grad():
+            logits = self.model(**inp).logits
+        probs = torch.softmax(logits, dim=-1)
+        if probs.size(-1) == 1:
+            return float(torch.sigmoid(logits)[0, 0])
+        return float(probs[0, -1])

--- a/tests/test_reward_utils.py
+++ b/tests/test_reward_utils.py
@@ -1,0 +1,20 @@
+import unittest
+from reward_utils import qa_reward
+
+
+class RewardUtilsTest(unittest.TestCase):
+    def test_exact_match(self):
+        pred = "Paris is the capital of France."
+        ref = "Paris is the capital of France"
+        self.assertAlmostEqual(qa_reward(pred, ref), 1.0)
+
+    def test_partial_match(self):
+        pred = "Paris"
+        ref = "Paris is the capital of France"
+        val = qa_reward(pred, ref)
+        self.assertGreater(val, 0.0)
+        self.assertLess(val, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `reward_utils` with F1-based QA reward and optional reward model
- update `grpo_train.py` to use the new reward function
- add unit tests for reward utilities

## Testing
- `pytest -q` *(fails: missing torch & numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68436497317083249cde0e5a40240e21