### PR TITLE
Add missing shutil import in llama_model

### DIFF
--- a/llama_model.py
+++ b/llama_model.py
@@ -12,6 +12,7 @@ except Exception:  # pragma: no cover - safetensors may be missing
     save_file = load_file = None  # type: ignore[misc]
 import os
 import json
+import shutil
 from tqdm import tqdm
 import numpy as np
 import time


### PR DESCRIPTION
## Summary
- ensure llama_model uses shutil at top level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68465e4df2b08324936f1c466723cafe