### PR TITLE
Improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,22 +2,31 @@
 
 This repository provides an implementation of the 1.58 BitNet LLaMA model. The project aims to reduce memory usage through ternary quantisation while keeping the training workflow close to standard LLaMA models.
 
-## Requirements
+## Requirements and Setup
+
+The code depends only on a few common packages:
 
 - `torch`
 - `transformers`
 - `datasets` (for dataset loading)
 - `safetensors`
 
-Install the dependencies with:
+Install them with:
 
 ```bash
 pip install torch transformers datasets safetensors
 ```
 
+The training scripts are tested on Apple MPS hardware but will run on any
+PyTorch device (CPU or CUDA).  Multi‑billion parameter models may require tens of
+gigabytes of RAM.
+
 ## Creating a Model
 
-Use `new-model-architecture-creation.py` to generate a blank ternary model. It prompts for the desired parameter count and saves the result in the current directory.
+Use `new-model-architecture-creation.py` to generate a blank ternary model.  The
+script asks for the desired parameter count and writes the model to a directory
+named `llama_<params>_ternary_quantized_optimized`.  Passing `--e` enables an
+experimental quantisation mode.
 
 ```bash
 python new-model-architecture-creation.py
@@ -25,7 +34,9 @@ python new-model-architecture-creation.py
 
 ## Cross‑Entropy Training
 
-`trainingv2.py` performs standard CE training on tokenised text datasets. The dataset may be a `.txt`, `.json` or `.jsonl` file.
+`trainingv2.py` performs standard CE training on tokenised text datasets.  The
+file may be plain text or a JSON/JSONL file containing a `text` field.  Each
+line or record is treated as one training example.
 
 ```bash
 python trainingv2.py --dataset path/to/data.jsonl --model_path path/to/model --output_dir ce_out --iters 1000
@@ -33,16 +44,28 @@ python trainingv2.py --dataset path/to/data.jsonl --model_path path/to/model --o
 
 ## GRPO Training
 
-`grpo_train.py` implements Grouped Response Policy Optimisation (GRPO). The dataset must contain pairs of queries and answers, formatted as JSON or JSONL with records of the form:
+`grpo_train.py` implements Grouped Response Policy Optimisation (GRPO).  The
+dataset should be JSON or JSONL with one object per record:
 
 ```json
 {"query": "...", "answer": "..."}
 ```
 
-A reward model can optionally be supplied via `--reward_model`; otherwise an F1 based reward is used.
+During training candidate answers are generated for each query and scored.  If
+`--reward_model PATH` is provided the score comes from a saved
+`RewardModel`; otherwise the robust F1 reward from `qa_reward` is used.
+
+Optional features:
+
+- `--config FILE` &ndash; JSON file with argument defaults.
+- `--two_layer` &ndash; enable the two stage trainer with self-correction.
+- `--csv_log LOG.csv` &ndash; append training metrics to a CSV file.
+- `--resume CKPT` &ndash; resume training from a checkpoint created with
+  `save_checkpoint`.
 
 ```bash
-python grpo_train.py --dataset qa.jsonl --model_path path/to/model --output_dir grpo_out --steps 1000
+python grpo_train.py --dataset qa.jsonl --model_path path/to/model \
+    --output_dir grpo_out --steps 1000 --csv_log metrics.csv
 ```
 
 ## Hardware and Example Commands
@@ -63,21 +86,40 @@ python grpo_train.py --dataset qa.jsonl --model_path llama_750m --reward_model r
 
 ## Evaluation
 
-`evaluation.py` compares a CE fine‑tuned model to a GRPO model using QA F1 score.
+`evaluation.py` compares a CE fine‑tuned model to a GRPO model using the same QA
+F1 reward as training.  The dataset format matches the GRPO training set
+(`{ "query": ..., "answer": ... }`).
 
 ```bash
 python evaluation.py --dataset qa.jsonl --ce_model ce_model --grpo_model grpo_model
 ```
 
 
-## Simple Reward Model Example
+## Reward Model Examples
 
-`simple_reward_model.py` illustrates how to build a tiny classifier for scoring question/answer pairs.  It trains a small linear model on a toy dataset and outputs reward probabilities for new pairs.
+Two reference implementations are provided for scoring generated answers:
 
-Run the demo with:
+- `simple_reward_model.py` – a minimal linear classifier trained on a small
+  labelled dataset.
+- `reward_model.py` – a more expressive Transformer based scorer supporting
+  contrastive training and saving/loading checkpoints.
+
+Run the demo for the simple model with:
 
 ```bash
 python simple_reward_model.py
 ```
 
-This prints higher scores for correct answers than incorrect ones and can be used as a starting point for custom reward models.
+The demo prints higher scores for correct answers and can be extended to create
+custom reward models for GRPO training.
+
+## Running the Tests
+
+Unit tests cover the data utilities, GRPO trainer, reward models and evaluation
+code.  Run them with:
+
+```bash
+pytest
+```
+
+All tests should pass; one test is skipped when WordNet data is unavailable.


### PR DESCRIPTION
## Summary
- detail dependency installation and hardware notes
- clarify dataset formats and add examples for model creation and CE training
- expand GRPO training documentation
- add section describing reward models
- document how to run the unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3d5e9e508324b2c2d97ab3aaeafd