### PR TITLE
Enable generative corrections in MultiLayerGRPOTrainer

### DIFF
--- a/grpo_train.py
+++ b/grpo_train.py
@@ -179,7 +179,13 @@ def main():
             return any(qa_reward(text, a) >= 0.8 for a in answers_holder["answers"])
 
         trainer = MultiLayerGRPOTrainer(
-            model, ref_model, verifier, clip_eps=args.clip_eps, beta=args.beta
+            model,
+            ref_model,
+            verifier,
+            tokenizer,
+            guiding_prompt="Fix the answer:",
+            clip_eps=args.clip_eps,
+            beta=args.beta,
         )
     else:
         trainer = GRPOTrainer(model, ref_model, clip_eps=args.clip_eps, beta=args.beta)


### PR DESCRIPTION
## Summary
- add tokenizer-driven guidance tokens to `MultiLayerGRPOTrainer`
- generate correction sequences after the first GRPO step
- update `grpo_train` to build the trainer with a guiding prompt
- extend `tests/test_mgrpo` with tokenizer and generate method

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3f6b33608324ba058a8129dac7e8