### PR TITLE
Add guiding prompt option

### DIFF
--- a/grpo_train.py
+++ b/grpo_train.py
@@ -121,6 +121,12 @@ def get_arg_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--log_interval", type=int, default=10, help="Steps between logging metrics")
     parser.add_argument("--csv_log", type=str, default=None, help="Optional CSV log file")
+    parser.add_argument(
+        "--guiding_prompt",
+        type=str,
+        default="Review and correct the answer:",
+        help="Guiding prompt for the second GRPO layer",
+    )
     parser.add_argument("--progress", action="store_true", help="Show progress bar if tqdm is available")
     return parser
 
@@ -183,7 +189,7 @@ def main():
             ref_model,
             verifier,
             tokenizer,
-            guiding_prompt="Fix the answer:",
+            guiding_prompt=args.guiding_prompt,
             clip_eps=args.clip_eps,
             beta=args.beta,
         )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,17 +6,19 @@ from grpo_train import get_arg_parser, update_args_with_config
 class ConfigTest(unittest.TestCase):
     def test_apply_config(self):
         parser = get_arg_parser()
-        cfg = {"lr": 0.5, "group_size": 4}
+        cfg = {"lr": 0.5, "group_size": 4, "guiding_prompt": "check"}
         with open("tmp_cfg.json", "w", encoding="utf-8") as f:
             json.dump(cfg, f)
         args = parser.parse_args(["--dataset", "d.json", "--model_path", "m", "--config", "tmp_cfg.json"])
         update_args_with_config(args, parser)
         self.assertEqual(args.lr, 0.5)
         self.assertEqual(args.group_size, 4)
+        self.assertEqual(args.guiding_prompt, "check")
         args = parser.parse_args(["--dataset", "d.json", "--model_path", "m", "--config", "tmp_cfg.json", "--lr", "0.1"])
         update_args_with_config(args, parser)
         self.assertEqual(args.lr, 0.1)
         self.assertEqual(args.group_size, 4)
+        self.assertEqual(args.guiding_prompt, "check")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add `--guiding_prompt` option to the training CLI
- pass this argument when creating `MultiLayerGRPOTrainer`
- extend configuration test to cover guiding prompt

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4e57f36c8324ad610fe54bddc1ea