### PR TITLE
Add reward function hook for second GRPO layer

### DIFF
--- a/grpo_train.py
+++ b/grpo_train.py
@@ -180,14 +180,13 @@ def main():
     if args.two_layer:
         answers_holder = {"answers": []}
 
-        def verifier(resp: torch.Tensor) -> bool:
-            text = tokenizer.decode(resp.tolist())
-            return any(qa_reward(text, a) >= 0.8 for a in answers_holder["answers"])
+        def second_layer_reward(text: str) -> float:
+            return max(qa_reward(text, a) for a in answers_holder["answers"])
 
         trainer = MultiLayerGRPOTrainer(
             model,
             ref_model,
-            verifier,
+            second_layer_reward,
             tokenizer,
             guiding_prompt=args.guiding_prompt,
             clip_eps=args.clip_eps,

--- a/tests/test_mgrpo.py
+++ b/tests/test_mgrpo.py
@@ -10,6 +10,9 @@ class DummyTokenizer:
     def encode(self, text, add_special_tokens=False):
         return [ord(c) % 10 + 2 for c in text.lower()]
 
+    def decode(self, tokens):
+        return " ".join(str(int(t)) for t in tokens)
+
 class DummyModel(torch.nn.Module):
     def __init__(self, vocab=10):
         super().__init__()
@@ -25,8 +28,9 @@ class DummyModel(torch.nn.Module):
         gen = torch.randint(0, self.linear.out_features, (B, L))
         return torch.cat([inp, gen], dim=1)
 
-def simple_verifier(resp: torch.Tensor) -> bool:
-    return int(resp[-1]) % 2 == 0
+def simple_reward(text: str) -> float:
+    last = int(text.split()[-1])
+    return float(last % 2 == 0)
 
 class GRPOTest(unittest.TestCase):
     def test_single_step(self):
@@ -48,7 +52,7 @@ class GRPOTest(unittest.TestCase):
         trainer = MultiLayerGRPOTrainer(
             model,
             ref,
-            simple_verifier,
+            simple_reward,
             tok,
             guiding_prompt="fix",
         )


### PR DESCRIPTION
## Summary
- allow `MultiLayerGRPOTrainer` to score second-layer generations with a custom `reward_fn`
- update the training script to compute rewards for corrections
- adapt unit tests to new interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ba8a4245883249f0734ea1af197e8