### PR TITLE
Add two-layer training integration test

### DIFF
--- a/tests/test_grpo_integration.py
+++ b/tests/test_grpo_integration.py
@@ -1,7 +1,7 @@
 import unittest
 import torch
 
-from grpo import GRPOTrainer
+from grpo import GRPOTrainer, MultiLayerGRPOTrainer
 from grpo_data import pad_sequences
 
 
@@ -11,6 +11,9 @@ class DummyTokenizer:
 
     def encode(self, text, add_special_tokens=False):
         return [(ord(c) % 5) + 2 for c in text.lower()]
+
+    def decode(self, tokens):
+        return " ".join(str(int(t)) for t in tokens)
 
 
 class DummyModel(torch.nn.Module):
@@ -22,6 +25,17 @@ class DummyModel(torch.nn.Module):
     def forward(self, x):
         emb = self.embed(x)
         return self.linear(emb)
+
+    def generate(self, inp, max_length, do_sample=True):
+        B = inp.size(0)
+        L = max_length - inp.size(1)
+        gen = torch.randint(0, self.linear.out_features, (B, L))
+        return torch.cat([inp, gen], dim=1)
+
+
+def simple_reward(text: str) -> float:
+    last = int(text.split()[-1])
+    return float(last % 2 == 0)
 
 
 class GRPOIntegrationTest(unittest.TestCase):
@@ -60,6 +74,46 @@ class GRPOIntegrationTest(unittest.TestCase):
         self.assertLess(final_loss, init_loss)
         changed = any(not torch.allclose(p, q) for p, q in zip(model.parameters(), init_params))
         self.assertTrue(changed)
+
+    def test_two_layer_training_loop(self):
+        torch.manual_seed(4)
+        data = [
+            {"query": "hi", "answer": "hello"},
+            {"query": "bye", "answer": "goodbye"},
+        ]
+        tok = DummyTokenizer()
+        q_tokens = [tok.encode(d["query"]) for d in data]
+        a_tokens = [tok.encode(d["answer"]) for d in data]
+        pad_id = tok.pad_token_id
+        queries = pad_sequences(q_tokens, pad_id)
+        max_resp = max(len(a) for a in a_tokens)
+        B, G = len(data), 2
+        responses = torch.full((B, G, max_resp), pad_id, dtype=torch.long)
+        lengths = torch.full((B, G), max_resp, dtype=torch.long)
+        rewards = torch.tensor([[0.0, 1.0], [0.0, 1.0]])
+        for i, ans in enumerate(a_tokens):
+            responses[i, 1, : len(ans)] = torch.tensor(ans)
+            responses[i, 0, : len(ans)] = torch.randint(2, 7, (len(ans),))
+        model = DummyModel()
+        ref = DummyModel()
+        trainer = MultiLayerGRPOTrainer(
+            model,
+            ref,
+            simple_reward,
+            tok,
+            guiding_prompt="fix",
+        )
+        optim = torch.optim.SGD(model.parameters(), lr=0.05)
+        init_params = [p.clone() for p in model.parameters()]
+        rates = []
+        for _ in range(3):
+            _, rate = trainer.train_batch(queries, responses, lengths, rewards, optim)
+            rates.append(rate)
+        changed = any(not torch.allclose(p, q) for p, q in zip(model.parameters(), init_params))
+        self.assertTrue(changed)
+        for r in rates:
+            self.assertGreaterEqual(r, 0.0)
+            self.assertLessEqual(r, 1.0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support decoding in DummyTokenizer
- add generate method and simple reward helper
- test MultiLayerGRPOTrainer training loop with parameter updates and valid correction rates

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684c5e315ea88324b2df1d40b255f20a