### PR TITLE
Add guiding_prompt config feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,23 @@ During training candidate answers are generated for each query and scored.  If
 
 Optional features:
 
-- `--config FILE` &ndash; JSON file with argument defaults.
+- `--config FILE` &ndash; JSON file with argument defaults (e.g. `guiding_prompt`).
 - `--two_layer` &ndash; enable the two stage trainer with self-correction.
 - `--csv_log LOG.csv` &ndash; append training metrics to a CSV file.
 - `--resume CKPT` &ndash; resume training from a checkpoint created with
   `save_checkpoint`.
+
+Example `config.json` providing defaults:
+
+```json
+{
+  "lr": 0.0005,
+  "group_size": 4,
+  "guiding_prompt": "Review and correct the answer:"
+}
+```
+`guiding_prompt` can be either the prompt text itself or a path to a file
+containing the text.
 
 ```bash
 python grpo_train.py --dataset qa.jsonl --model_path path/to/model \

--- a/grpo_train.py
+++ b/grpo_train.py
@@ -137,6 +137,11 @@ def update_args_with_config(args: argparse.Namespace, parser: argparse.ArgumentP
         return
     with open(args.config, "r", encoding="utf-8") as f:
         cfg = json.load(f)
+    if "guiding_prompt" in cfg:
+        gp = cfg["guiding_prompt"]
+        if isinstance(gp, str) and os.path.isfile(gp):
+            with open(gp, "r", encoding="utf-8") as pf:
+                cfg["guiding_prompt"] = pf.read().strip()
     for key, value in cfg.items():
         old_default = parser.get_default(key)
         parser.set_defaults(**{key: value})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,5 +20,15 @@ class ConfigTest(unittest.TestCase):
         self.assertEqual(args.group_size, 4)
         self.assertEqual(args.guiding_prompt, "check")
 
+    def test_guiding_prompt_file(self):
+        parser = get_arg_parser()
+        with open("prompt.txt", "w", encoding="utf-8") as f:
+            f.write("file prompt")
+        cfg = {"guiding_prompt": "prompt.txt"}
+        with open("tmp_cfg2.json", "w", encoding="utf-8") as f:
+            json.dump(cfg, f)
+        args = parser.parse_args(["--dataset", "d.json", "--model_path", "m", "--config", "tmp_cfg2.json"])
+        update_args_with_config(args, parser)
+        self.assertEqual(args.guiding_prompt, "file prompt")
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow `update_args_with_config` to read guiding prompts from files
- document guiding prompts in config usage
- test reading guiding prompts from files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68549a3bf3548324a363e6b5b40ac9fe