### PR TITLE
Add sample corrections to CSV logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ Optional features:
 
 - `--config FILE` &ndash; JSON file with argument defaults (e.g. `guiding_prompt`).
 - `--two_layer` &ndash; enable the two stage trainer with self-correction.
-- `--csv_log LOG.csv` &ndash; append training metrics to a CSV file.
+- `--csv_log LOG.csv` &ndash; append metrics to a CSV file. When `--two_layer` is
+  active the log also includes up to three `corrected_n` columns with corrected
+  answers for inspection.
 - `--resume CKPT` &ndash; resume training from a checkpoint created with
   `save_checkpoint`.
 

--- a/tests/test_mgrpo.py
+++ b/tests/test_mgrpo.py
@@ -116,5 +116,31 @@ class GRPOTest(unittest.TestCase):
         self.assertTrue(torch.equal(model.calls[0][0], expected_inp))
         self.assertTrue(torch.equal(captured["rewards"], torch.tensor([[1.0]])))
 
+    def test_log_texts(self):
+        model = DummyModel()
+        ref = DummyModel()
+        tok = DummyTokenizer()
+        trainer = MultiLayerGRPOTrainer(
+            model,
+            ref,
+            simple_reward,
+            tok,
+            guiding_prompt="fix",
+        )
+        optim = torch.optim.SGD(model.parameters(), lr=0.01)
+        queries = torch.randint(0, 10, (1, 3))
+        responses = torch.randint(0, 10, (1, 2, 4))
+        lengths = torch.tensor([[4, 4]])
+        rewards = torch.tensor([[0.0, 1.0]])
+        loss, rate, texts = trainer.train_batch(
+            queries,
+            responses,
+            lengths,
+            rewards,
+            optim,
+            log_texts=2,
+        )
+        self.assertEqual(len(texts), 2)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- log corrected text for a few samples when CSV logging is enabled
- expose new `log_texts` option in `MultiLayerGRPOTrainer.train_batch`
- mention corrected samples in README
- add unit test for returning logged texts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a28635108324821c3a5f5e5faacd