### PR TITLE
Add second_max_length option for corrections

### DIFF
--- a/grpo.py
+++ b/grpo.py
@@ -84,6 +84,7 @@ class MultiLayerGRPOTrainer:
         clip_eps: float = 0.2,
         beta: float = 0.01,
         verifier: Callable[[float, float], bool] | None = None,
+        second_max_length: int = 20,
     ):
         self.layer1 = GRPOTrainer(model, ref_model, clip_eps, beta)
         self.layer2 = GRPOTrainer(model, ref_model, clip_eps, beta)
@@ -98,6 +99,7 @@ class MultiLayerGRPOTrainer:
             pad_id = getattr(tokenizer, "eos_token_id", 0)
         self.pad_id = pad_id
         self.verifier = verifier
+        self.second_max_length = second_max_length
 
     def train_batch(
         self,
@@ -132,7 +134,7 @@ class MultiLayerGRPOTrainer:
                 with torch.no_grad():
                     gen = self.layer2.model.generate(
                         inp.unsqueeze(0),
-                        max_length=inp_len + L,
+                        max_length=inp_len + self.second_max_length,
                         do_sample=True,
                     )
                 new_resp = gen[0, inp_len:]

--- a/grpo_train.py
+++ b/grpo_train.py
@@ -107,6 +107,12 @@ def get_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument("--group_size", type=int, default=2)
     parser.add_argument("--steps", type=int, default=100)
     parser.add_argument("--max_length", type=int, default=20)
+    parser.add_argument(
+        "--second_max_length",
+        type=int,
+        default=20,
+        help="Number of tokens to generate for the correction step",
+    )
     parser.add_argument("--lr", type=float, default=1e-5)
     parser.add_argument("--clip_eps", type=float, default=0.2)
     parser.add_argument("--beta", type=float, default=0.01)
@@ -209,6 +215,7 @@ def main():
             clip_eps=args.clip_eps,
             beta=args.beta,
             verifier=simple_improvement_verifier,
+            second_max_length=args.second_max_length,
         )
     else:
         trainer = GRPOTrainer(model, ref_model, clip_eps=args.clip_eps, beta=args.beta)


### PR DESCRIPTION
## Summary
- add `--second_max_length` option to CLI
- pass argument through to `MultiLayerGRPOTrainer`
- support generation length control in correction step

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854a73833d48324aea3137a5fb66f84