### PR TITLE
Add query length tracking for GRPO batches

### DIFF
--- a/grpo.py
+++ b/grpo.py
@@ -104,6 +104,7 @@ class MultiLayerGRPOTrainer:
     def train_batch(
         self,
         queries: torch.Tensor,
+        query_lengths: torch.Tensor,
         responses: torch.Tensor,
         lengths: torch.Tensor,
         rewards: torch.Tensor,
@@ -128,10 +129,11 @@ class MultiLayerGRPOTrainer:
         log_text_list: list[str] = []
         success = 0
         for b in range(B):
+            q_tokens = queries[b, : query_lengths[b]]
             for g in range(G):
                 resp = responses[b, g, : lengths[b, g]]
                 inp, inp_len = construct_second_pass_input(
-                    queries[b], resp, self.guidance_tokens
+                    q_tokens, resp, self.guidance_tokens
                 )
                 with torch.no_grad():
                     gen = self.layer2.model.generate(

--- a/grpo_data.py
+++ b/grpo_data.py
@@ -42,12 +42,13 @@ def build_grpo_batch(
     group_size: int,
     max_length: int,
     reward_fn: Callable[[str, str, str], float] = f1_reward,
-) -> (torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor):
+) -> (torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor):
     """Generate candidate responses and compute rewards."""
     q_tokens = [tokenizer.encode(s['query'], add_special_tokens=False) for s in samples]
     answers = [s['answer'] for s in samples]
     pad_id = tokenizer.pad_token_id or tokenizer.eos_token_id
     queries = pad_sequences(q_tokens, pad_id)
+    q_lens = torch.tensor([len(q) for q in q_tokens], dtype=torch.long)
 
     B = len(samples)
     responses = []
@@ -79,7 +80,7 @@ def build_grpo_batch(
             resp_tensor[b, g, :len(seq)] = torch.tensor(seq, dtype=torch.long)
             len_tensor[b, g] = len(seq)
     reward_tensor = torch.tensor(rewards, dtype=torch.float)
-    return queries, resp_tensor, len_tensor, reward_tensor
+    return queries, q_lens, resp_tensor, len_tensor, reward_tensor
 
 
 def construct_second_pass_input(

--- a/tests/test_grpo_data.py
+++ b/tests/test_grpo_data.py
@@ -24,10 +24,11 @@ class GRPODataTest(unittest.TestCase):
         data = [{'query': 'hi', 'answer': 'hello'}]
         tok = DummyTokenizer()
         model = DummyModel()
-        q, r, l, rew = build_grpo_batch(
+        q, ql, r, l, rew = build_grpo_batch(
             data, tok, model, group_size=2, max_length=3, reward_fn=f1_reward
         )
         self.assertEqual(q.size(0), 1)
+        self.assertEqual(ql.shape, (1,))
         self.assertEqual(r.shape[:2], (1,2))
         self.assertEqual(l.shape, (1,2))
         self.assertEqual(rew.shape, (1,2))

--- a/tests/test_grpo_integration.py
+++ b/tests/test_grpo_integration.py
@@ -50,6 +50,7 @@ class GRPOIntegrationTest(unittest.TestCase):
         a_tokens = [tok.encode(d["answer"]) for d in data]
         pad_id = tok.pad_token_id
         queries = pad_sequences(q_tokens, pad_id)
+        q_lens = torch.tensor([len(q) for q in q_tokens], dtype=torch.long)
         max_resp = max(len(a) for a in a_tokens)
         B, G = len(data), 2
         responses = torch.full((B, G, max_resp), pad_id, dtype=torch.long)
@@ -86,6 +87,7 @@ class GRPOIntegrationTest(unittest.TestCase):
         a_tokens = [tok.encode(d["answer"]) for d in data]
         pad_id = tok.pad_token_id
         queries = pad_sequences(q_tokens, pad_id)
+        q_lens = torch.tensor([len(q) for q in q_tokens], dtype=torch.long)
         max_resp = max(len(a) for a in a_tokens)
         B, G = len(data), 2
         responses = torch.full((B, G, max_resp), pad_id, dtype=torch.long)
@@ -107,7 +109,7 @@ class GRPOIntegrationTest(unittest.TestCase):
         init_params = [p.clone() for p in model.parameters()]
         rates = []
         for _ in range(3):
-            _, rate = trainer.train_batch(queries, responses, lengths, rewards, optim)
+            _, rate = trainer.train_batch(queries, q_lens, responses, lengths, rewards, optim)
             rates.append(rate)
         changed = any(not torch.allclose(p, q) for p, q in zip(model.parameters(), init_params))
         self.assertTrue(changed)

--- a/tests/test_mgrpo.py
+++ b/tests/test_mgrpo.py
@@ -58,10 +58,11 @@ class GRPOTest(unittest.TestCase):
         )
         optim = torch.optim.SGD(model.parameters(), lr=0.01)
         queries = torch.randint(0, 10, (1, 3))
+        ql = torch.full((1,), queries.size(1), dtype=torch.long)
         responses = torch.randint(0, 10, (1, 2, 4))
         lengths = torch.tensor([[4,4]])
         rewards = torch.tensor([[0.0,1.0]])
-        loss, rate = trainer.train_batch(queries, responses, lengths, rewards, optim)
+        loss, rate = trainer.train_batch(queries, ql, responses, lengths, rewards, optim)
         self.assertIsInstance(loss.item(), float)
         self.assertGreaterEqual(rate, 0.0)
         self.assertLessEqual(rate, 1.0)
@@ -102,11 +103,12 @@ class GRPOTest(unittest.TestCase):
 
         optim = torch.optim.SGD(model.parameters(), lr=0.01)
         queries = torch.tensor([[2, 3]], dtype=torch.long)
+        ql = torch.full((1,), queries.size(1), dtype=torch.long)
         responses = torch.tensor([[[4, 5, 6, 7]]], dtype=torch.long)
         lengths = torch.tensor([[4]], dtype=torch.long)
         rewards = torch.tensor([[0.0]], dtype=torch.float)
 
-        loss, rate = trainer.train_batch(queries, responses, lengths, rewards, optim)
+        loss, rate = trainer.train_batch(queries, ql, responses, lengths, rewards, optim)
         self.assertIsInstance(loss.item(), float)
         self.assertEqual(rate, 1.0)
 
@@ -129,11 +131,13 @@ class GRPOTest(unittest.TestCase):
         )
         optim = torch.optim.SGD(model.parameters(), lr=0.01)
         queries = torch.randint(0, 10, (1, 3))
+        ql = torch.full((1,), queries.size(1), dtype=torch.long)
         responses = torch.randint(0, 10, (1, 2, 4))
         lengths = torch.tensor([[4, 4]])
         rewards = torch.tensor([[0.0, 1.0]])
         loss, rate, texts = trainer.train_batch(
             queries,
+            ql,
             responses,
             lengths,
             rewards,
@@ -155,6 +159,7 @@ class GRPOTest(unittest.TestCase):
         )
         optim = torch.optim.SGD(model.parameters(), lr=0.01)
         queries = torch.randint(0, 10, (1, 3))
+        ql = torch.full((1,), queries.size(1), dtype=torch.long)
         responses = torch.randint(0, 10, (1, 2, 4))
         lengths = torch.tensor([[4, 4]])
         rewards = torch.tensor([[0.0, 1.0]])
@@ -169,7 +174,7 @@ class GRPOTest(unittest.TestCase):
             return torch.tensor(0.0)
 
         trainer.layer2.step = layer2_step
-        trainer.train_batch(queries, responses, lengths, rewards, optim)
+        trainer.train_batch(queries, ql, responses, lengths, rewards, optim)
         self.assertTrue(called["ok"])
         changed = any(
             not torch.allclose(p, q) for p, q in zip(model.parameters(), init_params)


### PR DESCRIPTION
## Summary
- return query lengths from `build_grpo_batch` and `prepare_batch`
- trim queries in `MultiLayerGRPOTrainer.train_batch`
- adjust training loop and tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c00e7fdc8324a5c06e543ca94328