### PR TITLE
Implement packed weights for HBitLinear

### DIFF
--- a/h_bitlinear.py
+++ b/h_bitlinear.py
@@ -6,25 +6,66 @@ def hadamard(n):
 import math
 import torch
 import torch.nn as nn
-from quantization_utils import act_quant_4bit, weight_quant
+from quantization_utils import (
+    act_quant_4bit,
+    quantize_tensor_1_58bit,
+    gemm_lowbit,
+    pack_ternary,
+    unpack_ternary,
+)
 
 class HBitLinear(nn.Linear):
-    """Linear layer with Hadamard transform for activations and 1-bit weights."""
-    def __init__(self, in_features, out_features, bias=True):
+    """Linear layer with Hadamard transform and packed 1.58-bit weights."""
+
+    def __init__(self, in_features: int, out_features: int, bias: bool = True):
         super().__init__(in_features, out_features, bias)
-        # Precompute Hadamard matrix for input dimension if power of two
         if (in_features & (in_features - 1)) == 0:
-            self.register_buffer('hadamard', torch.tensor(hadamard(in_features), dtype=torch.float32), persistent=False)
+            self.register_buffer(
+                "hadamard",
+                torch.tensor(hadamard(in_features), dtype=torch.float32),
+                persistent=False,
+            )
         else:
             self.hadamard = None
         self.eps = 1e-5
 
-    def forward(self, x):
+        self.register_buffer("packed_weight", torch.empty(0, dtype=torch.uint8))
+        self.register_buffer("weight_scale", torch.tensor(1.0))
+
+        self.pack()
+
+    def pack(self):
+        q, scale = quantize_tensor_1_58bit(self.weight, self.eps)
+        self.packed_weight = pack_ternary(q)
+        self.weight_scale = scale
+        del self.weight
+        self.register_parameter("weight", None)
+
+    def unpack(self) -> torch.Tensor:
+        return unpack_ternary(self.packed_weight, (self.out_features, self.in_features))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:  # type: ignore[override]
         if self.hadamard is not None:
-            # Apply Hadamard transform
             x = torch.matmul(x, self.hadamard) / math.sqrt(self.in_features)
-        # Quantize activations to 4-bit
-        x = act_quant_4bit(x)
-        # Quantize weights to 1-bit
-        w = weight_quant(self.weight)
-        return nn.functional.linear(x, w, self.bias)
+
+        a_scale = 7.0 / x.abs().max(dim=-1, keepdim=True).values.clamp_(min=self.eps)
+        x_q = (x * a_scale).round().clamp_(-8, 7).to(torch.int8)
+
+        w_q = self.unpack()
+        out_int = gemm_lowbit(x_q, w_q)
+        out = out_int.to(torch.float32) * self.weight_scale / a_scale
+        if self.bias is not None:
+            out += self.bias
+        return out
+
+
+def convert_linear_to_hbitlinear(linear: nn.Linear) -> HBitLinear:
+    """Create an :class:`HBitLinear` from a trained :class:`torch.nn.Linear`."""
+
+    layer = HBitLinear(linear.in_features, linear.out_features, bias=linear.bias is not None)
+    if linear.bias is not None:
+        layer.bias.data.copy_(linear.bias.data)
+    # Temporarily assign weight for packing
+    layer.register_parameter("weight", nn.Parameter(linear.weight.detach().clone()))
+    layer.pack()
+    return layer

--- a/tests/test_h_bitlinear.py
+++ b/tests/test_h_bitlinear.py
@@ -1,6 +1,7 @@
 import torch
 import unittest
-from h_bitlinear import HBitLinear
+from h_bitlinear import HBitLinear, convert_linear_to_hbitlinear
+import torch.nn as nn
 
 class HBitLinearTest(unittest.TestCase):
     def test_forward_shape(self):
@@ -8,6 +9,16 @@ class HBitLinearTest(unittest.TestCase):
         inp = torch.randn(3, 4)
         out = layer(inp)
         self.assertEqual(out.shape, (3, 2))
+
+    def test_numerical_close(self):
+        torch.manual_seed(0)
+        lin = nn.Linear(3, 2)
+        x = torch.randn(4, 3)
+        ref = lin(x)
+        hlin = convert_linear_to_hbitlinear(lin)
+        out = hlin(x)
+        rel_err = torch.mean(torch.abs(out - ref)) / torch.mean(torch.abs(ref))
+        self.assertLess(rel_err.item(), 0.75)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add ternary packing utilities in `quantization_utils`
- rework `HBitLinear` to hold packed 1.58‑bit weights and use `gemm_lowbit`
- provide `convert_linear_to_hbitlinear` helper
- check numerical accuracy of `HBitLinear`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a004bec48324a10452933123d5af