### PR TITLE
Add CLI argument parsing to inference utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,33 @@ The correction concatenates the query, the first answer and the text from
 `--guiding_prompt` (default "Review and correct the answer:") before generating
 the final response.
 
+## Inference
+
+`inference.py` generates text from a saved model. Provide one or more prompts on
+the command line:
+
+```bash
+python inference.py --model_path path/to/model --prompt "Hello" --prompt "World"
+```
+
+The script can also be imported and called programmatically:
+
+```python
+from inference import run
+run("path/to/model", ["Hello"], max_length=20)
+```
+
+## Transformers Compatibility
+
+`data_loading_compatibility.py` demonstrates loading a checkpoint with
+`transformers` and generating text:
+
+```bash
+python data_loading_compatibility.py --model_path path/to/model --text "Example"
+```
+
+The `run` function can be used directly from Python for integration tests.
+
 
 ## Reward Model Examples
 
@@ -134,7 +161,7 @@ Two reference implementations are provided for scoring generated answers:
 Run the demo for the simple model with:
 
 ```bash
-python simple_reward_model.py
+python simple_reward_model.py --epochs 100 --lr 0.1
 ```
 
 The demo prints higher scores for correct answers and can be extended to create

--- a/data_loading_compatibility.py
+++ b/data_loading_compatibility.py
@@ -1,83 +1,75 @@
-from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
-import torch
-from safetensors.torch import load
+import argparse
 import os
+import torch
+from transformers import AutoTokenizer, AutoModelForCausalLM, AutoConfig
+from safetensors.torch import load
 
 def preprocess_data(data, tokenizer):
     input_ids = tokenizer.encode(data, return_tensors='pt')
     attention_mask = torch.ones_like(input_ids)
     return input_ids, attention_mask
 
-model_path = input("Enter the path to your optimized model: ")
-tokenizer = AutoTokenizer.from_pretrained(model_path)
+def load_model(model_path: str):
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    config = AutoConfig.from_pretrained(model_path)
+    model_state_dict_path = os.path.join(model_path, "model.safetensors")
+    with open(model_state_dict_path, "rb") as f:
+        data = f.read()
+    model_state_dict = load(data)
 
-config = AutoConfig.from_pretrained(model_path)
+    adjusted_model_state_dict = {
+        key.replace("model.", ""): value for key, value in model_state_dict.items()
+    }
+    model = AutoModelForCausalLM.from_config(config)
 
-# Correctly reading the .safetensors file in binary mode and loading it
-model_state_dict_path = os.path.join(model_path, "model.safetensors")
-with open(model_state_dict_path, "rb") as f:
-    data = f.read()
+    vocab_size = config.vocab_size
+    hidden_size = config.hidden_size
+    expected = vocab_size * hidden_size
+    actual = adjusted_model_state_dict["lm_head.weight"].numel()
 
-model_state_dict = load(data)
+    if actual != expected:
+        loaded = adjusted_model_state_dict["lm_head.weight"]
+        new = torch.zeros(vocab_size, hidden_size, dtype=loaded.dtype, device=loaded.device)
+        n = min(actual, expected)
+        new.view(-1)[:n] = loaded.view(-1)[:n]
+        adjusted_model_state_dict["lm_head.weight"] = new
+    else:
+        adjusted_model_state_dict["lm_head.weight"] = adjusted_model_state_dict["lm_head.weight"].view(vocab_size, hidden_size)
 
-# Print the keys of the loaded state dictionary for debugging
-print("Loaded state dictionary keys:")
-for key in model_state_dict.keys():
-    print(key)
+    model.load_state_dict(adjusted_model_state_dict, strict=False)
+    device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
+    model.to(device)
+    return model, tokenizer
 
-# Create a new model instance with the loaded config
-model = AutoModelForCausalLM.from_config(config)
+def run(model_path: str, text: str, max_length: int = 100) -> str:
+    model, tokenizer = load_model(model_path)
+    input_ids, attention_mask = preprocess_data(text, tokenizer)
+    with torch.no_grad():
+        outputs = model.generate(
+            input_ids,
+            attention_mask=attention_mask,
+            max_length=max_length,
+            pad_token_id=tokenizer.eos_token_id,
+            eos_token_id=tokenizer.eos_token_id,
+        )
+    generated_text = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    print("Generated text:", generated_text)
+    return generated_text
 
-# Print the keys of the model's state dictionary for debugging
-print("Model state dictionary keys:")
-for key in model.state_dict().keys():
-    print(key)
 
-# Load the state dictionary into the model
-# Adjust keys to remove 'model.' prefix
-adjusted_model_state_dict = {key.replace('model.', ''): value for key, value in model_state_dict.items()}
+def get_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Load a model and generate text using transformers")
+    parser.add_argument("--model_path", required=True)
+    parser.add_argument("--text", required=True)
+    parser.add_argument("--max_length", type=int, default=100)
+    return parser
 
-# Check if the size of lm_head.weight matches the expected shape
-vocab_size = config.vocab_size
-hidden_size = config.hidden_size
-expected_lm_head_size = vocab_size * hidden_size
-actual_lm_head_size = adjusted_model_state_dict['lm_head.weight'].numel()
 
-if actual_lm_head_size != expected_lm_head_size:
-    print(f"Warning: The size of 'lm_head.weight' in the loaded state dictionary ({actual_lm_head_size}) does not match the expected size ({expected_lm_head_size}).")
-    print("Creating a new tensor with the expected shape and copying the values.")
+def main(argv: list[str] | None = None) -> None:
+    parser = get_arg_parser()
+    args = parser.parse_args(argv)
+    run(args.model_path, args.text, max_length=args.max_length)
 
-    loaded_lm_head_weight = adjusted_model_state_dict['lm_head.weight']
-    new_lm_head_weight = torch.zeros(vocab_size, hidden_size, dtype=loaded_lm_head_weight.dtype, device=loaded_lm_head_weight.device)
 
-    # Copy the values from the loaded tensor to the new tensor
-    num_elements_to_copy = min(actual_lm_head_size, expected_lm_head_size)
-    new_lm_head_weight.view(-1)[:num_elements_to_copy] = loaded_lm_head_weight.view(-1)[:num_elements_to_copy]
-
-    adjusted_model_state_dict['lm_head.weight'] = new_lm_head_weight
-
-else:
-    adjusted_model_state_dict['lm_head.weight'] = adjusted_model_state_dict['lm_head.weight'].view(vocab_size, hidden_size)
-
-# Load the adjusted state dictionary into the model
-model.load_state_dict(adjusted_model_state_dict, strict=False)
-
-# Move the model to the appropriate device
-device = torch.device("mps" if torch.backends.mps.is_available() else "cpu")
-model.to(device)
-
-# Example usage
-input_text = input("Enter the text to process: ")
-input_ids, attention_mask = preprocess_data(input_text, tokenizer)
-
-with torch.no_grad():
-    outputs = model.generate(
-        input_ids,
-        attention_mask=attention_mask,
-        max_length=100,
-        pad_token_id=tokenizer.eos_token_id,
-        eos_token_id=tokenizer.eos_token_id,
-    )
-
-generated_text = tokenizer.decode(outputs[0], skip_special_tokens=True)
-print("Generated text:", generated_text)
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -1,0 +1,29 @@
+import unittest
+from unittest import mock
+import importlib
+
+TRANS_AVAILABLE = importlib.util.find_spec("transformers") is not None
+
+if TRANS_AVAILABLE:
+    import inference
+    import data_loading_compatibility as dlc
+
+
+@unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
+class InferenceCLITest(unittest.TestCase):
+    def test_main_calls_run(self):
+        with mock.patch('inference.run') as run:
+            inference.main(['--model_path', 'm', '--prompt', 'hi'])
+            run.assert_called_with('m', ['hi'], max_length=100, evaluate=False)
+
+
+@unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
+class DataLoadingCLITest(unittest.TestCase):
+    def test_main_calls_run(self):
+        with mock.patch('data_loading_compatibility.run') as run:
+            dlc.main(['--model_path', 'm', '--text', 'hi'])
+            run.assert_called_with('m', 'hi', max_length=100)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- refactor `inference.py` with argparse and a reusable `run` API
- refactor `data_loading_compatibility.py` into a callable module with argparse
- document the new CLIs in README
- add tests for the new command-line interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a37f40888324b371f52e6e81e9d2