### PR TITLE
Add reasoning dataset loaders and metrics

### DIFF
--- a/evaluation.py
+++ b/evaluation.py
@@ -1,8 +1,11 @@
 import argparse
 import torch
 from llama_model import LlamaModel
-from grpo_data import load_qa_dataset, construct_second_pass_input
-from reward_utils import qa_reward
+from grpo_data import (
+    load_qa_dataset,
+    construct_second_pass_input,
+)
+from reward_utils import qa_reward, accuracy_reward
 
 
 def generate_response(
@@ -63,12 +66,85 @@ def evaluate_model(
     return sum(scores) / len(scores)
 
 
+def evaluate_reasoning_model(
+    model,
+    tokenizer,
+    dataset,
+    max_length: int,
+    *,
+    two_layer: bool = False,
+    guiding_prompt: str = "Review and correct the answer:",
+    second_max_length: int = 20,
+) -> dict:
+    """Evaluate ``model`` on a reasoning dataset using accuracy metrics."""
+
+    correct_first = 0
+    correct_second = 0
+    changed_ic = 0
+    changed_ci = 0
+    if two_layer:
+        guidance_tokens = torch.tensor(
+            tokenizer.encode(guiding_prompt, add_special_tokens=False),
+            dtype=torch.long,
+        )
+        sep = getattr(tokenizer, "sep_token_id", None)
+        if sep is None:
+            sep = getattr(tokenizer, "eos_token_id", 0)
+        sep = int(sep)
+    for sample in dataset:
+        query_tokens = tokenizer.encode(sample["query"], add_special_tokens=False)
+        inp = torch.tensor([query_tokens], dtype=torch.long)
+        out = model.generate(inp, max_length=len(query_tokens) + max_length, do_sample=False)
+        first_resp = out[0, len(query_tokens):]
+        first_text = tokenizer.decode(first_resp.tolist())
+        first_ok = bool(accuracy_reward(first_text, sample["answer"]))
+        if two_layer:
+            q_tokens = torch.tensor(query_tokens, dtype=torch.long)
+            sec_inp, sec_len = construct_second_pass_input(
+                q_tokens,
+                first_resp,
+                guidance_tokens,
+                sep,
+            )
+            gen = model.generate(
+                sec_inp.unsqueeze(0),
+                max_length=sec_len + second_max_length,
+                do_sample=False,
+            )
+            final_resp = gen[0, sec_len:]
+            final_text = tokenizer.decode(final_resp.tolist())
+        else:
+            final_text = first_text
+        second_ok = bool(accuracy_reward(final_text, sample["answer"]))
+
+        correct_first += first_ok
+        correct_second += second_ok
+        if not first_ok and second_ok:
+            changed_ic += 1
+        if first_ok and not second_ok:
+            changed_ci += 1
+
+    N = len(dataset)
+    return {
+        "accuracy_t1": correct_first / N,
+        "accuracy_t2": correct_second / N,
+        "delta_i2c": changed_ic / N,
+        "delta_c2i": changed_ci / N,
+    }
+
+
 def main():
     parser = argparse.ArgumentParser(description="Evaluate GRPO vs CE models")
     parser.add_argument("--dataset", type=str, required=True)
     parser.add_argument("--ce_model", type=str, required=True)
     parser.add_argument("--grpo_model", type=str, required=True)
     parser.add_argument("--max_length", type=int, default=20)
+    parser.add_argument(
+        "--task",
+        choices=["qa", "reasoning"],
+        default="qa",
+        help="Type of dataset: 'qa' uses F1 reward, 'reasoning' uses accuracy",
+    )
     parser.add_argument(
         "--two_layer",
         action="store_true",
@@ -88,34 +164,72 @@ def main():
     )
     args = parser.parse_args()
 
-    data = load_qa_dataset(args.dataset)
+    if args.dataset.lower() == "math":
+        from grpo_data import load_math_dataset
+        data = load_math_dataset()
+    elif args.dataset.lower() == "gsm8k":
+        from grpo_data import load_gsm8k_dataset
+        data = load_gsm8k_dataset()
+    elif args.dataset.lower() == "minerva":
+        from grpo_data import load_minerva_math_dataset
+        data = load_minerva_math_dataset()
+    elif args.dataset.lower() == "olympiadbench":
+        from grpo_data import load_olympiadbench_dataset
+        data = load_olympiadbench_dataset()
+    else:
+        data = load_qa_dataset(args.dataset)
     from transformers import AutoTokenizer
     ce_tok = AutoTokenizer.from_pretrained(args.ce_model)
     grpo_tok = AutoTokenizer.from_pretrained(args.grpo_model)
     ce_model = LlamaModel.load_pretrained(args.ce_model)
     grpo_model = LlamaModel.load_pretrained(args.grpo_model)
 
-    ce_score = evaluate_model(
-        ce_model,
-        ce_tok,
-        data,
-        args.max_length,
-        two_layer=args.two_layer,
-        guiding_prompt=args.guiding_prompt,
-        second_max_length=args.second_max_length,
-    )
-    grpo_score = evaluate_model(
-        grpo_model,
-        grpo_tok,
-        data,
-        args.max_length,
-        two_layer=args.two_layer,
-        guiding_prompt=args.guiding_prompt,
-        second_max_length=args.second_max_length,
-    )
-
-    print(f"CE model F1: {ce_score:.4f}")
-    print(f"GRPO model F1: {grpo_score:.4f}")
+    if args.task == "qa":
+        ce_score = evaluate_model(
+            ce_model,
+            ce_tok,
+            data,
+            args.max_length,
+            two_layer=args.two_layer,
+            guiding_prompt=args.guiding_prompt,
+            second_max_length=args.second_max_length,
+        )
+        grpo_score = evaluate_model(
+            grpo_model,
+            grpo_tok,
+            data,
+            args.max_length,
+            two_layer=args.two_layer,
+            guiding_prompt=args.guiding_prompt,
+            second_max_length=args.second_max_length,
+        )
+        print(f"CE model F1: {ce_score:.4f}")
+        print(f"GRPO model F1: {grpo_score:.4f}")
+    else:
+        ce_metrics = evaluate_reasoning_model(
+            ce_model,
+            ce_tok,
+            data,
+            args.max_length,
+            two_layer=args.two_layer,
+            guiding_prompt=args.guiding_prompt,
+            second_max_length=args.second_max_length,
+        )
+        grpo_metrics = evaluate_reasoning_model(
+            grpo_model,
+            grpo_tok,
+            data,
+            args.max_length,
+            two_layer=args.two_layer,
+            guiding_prompt=args.guiding_prompt,
+            second_max_length=args.second_max_length,
+        )
+        print("CE model metrics:")
+        for k, v in ce_metrics.items():
+            print(f"  {k}: {v:.4f}")
+        print("GRPO model metrics:")
+        for k, v in grpo_metrics.items():
+            print(f"  {k}: {v:.4f}")
 
 
 if __name__ == "__main__":

--- a/grpo_data.py
+++ b/grpo_data.py
@@ -27,6 +27,38 @@ def load_qa_dataset(path: str) -> List[Dict[str, str]]:
     return data
 
 
+def load_math_dataset(split: str = "test[:500]") -> List[Dict[str, str]]:
+    """Load the MATH benchmark via the :mod:`datasets` library."""
+    from datasets import load_dataset
+
+    ds = load_dataset("hendrycks/math", split=split)
+    return [{"query": x["problem"], "answer": x["solution"]} for x in ds]
+
+
+def load_gsm8k_dataset(split: str = "test") -> List[Dict[str, str]]:
+    """Load the GSM8K dataset."""
+    from datasets import load_dataset
+
+    ds = load_dataset("openai/gsm8k", "main", split=split)
+    return [{"query": x["question"], "answer": x["answer"]} for x in ds]
+
+
+def load_minerva_math_dataset(split: str = "test") -> List[Dict[str, str]]:
+    """Load the Minerva Math dataset used in the paper."""
+    from datasets import load_dataset
+
+    ds = load_dataset("knoveleng/Minerva-Math", split=split)
+    return [{"query": x["problem"], "answer": x["solution"]} for x in ds]
+
+
+def load_olympiadbench_dataset(split: str = "test") -> List[Dict[str, str]]:
+    """Load the OlympiadBench dataset."""
+    from datasets import load_dataset
+
+    ds = load_dataset("lmms-lab/OlympiadBench", split=split)
+    return [{"query": x["problem"], "answer": x["solution"]} for x in ds]
+
+
 def pad_sequences(seqs: List[List[int]], pad_id: int) -> torch.Tensor:
     max_len = max(len(s) for s in seqs)
     tensor = torch.full((len(seqs), max_len), pad_id, dtype=torch.long)


### PR DESCRIPTION
## Summary
- support loading reasoning benchmarks like MATH, GSM8K, Minerva and OlympiadBench
- add accuracy-based reward helpers for reasoning tasks
- extend evaluation script with reasoning metrics and dataset options
- test evaluation of reasoning datasets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855ccedf280832484d65d853afd859b