### PR TITLE
Add cosine scheduler and checkpoint resume support

### DIFF
--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -1,7 +1,7 @@
 import os
 import torch
 import unittest
-from grpo_train import save_checkpoint, load_checkpoint
+from training_utils import save_checkpoint, load_checkpoint
 
 class DummyModel(torch.nn.Module):
     def __init__(self):

--- a/tests/test_resume.py
+++ b/tests/test_resume.py
@@ -1,0 +1,54 @@
+import os
+import torch
+import unittest
+from training_utils import save_checkpoint, load_checkpoint
+
+class SimpleModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.randn(1))
+
+    def forward(self):
+        return self.w
+
+class ResumeBehaviourTest(unittest.TestCase):
+    def test_resume_updates(self):
+        torch.manual_seed(0)
+        model_full = SimpleModel()
+        optim_full = torch.optim.SGD(model_full.parameters(), lr=0.1)
+
+        torch.manual_seed(0)
+        model_resume = SimpleModel()
+        optim_resume = torch.optim.SGD(model_resume.parameters(), lr=0.1)
+
+        # Train full model for 4 steps
+        for _ in range(4):
+            loss = (model_full() ** 2).sum()
+            loss.backward()
+            optim_full.step()
+            optim_full.zero_grad()
+
+        # Train resume model for 2 steps then save
+        for _ in range(2):
+            loss = (model_resume() ** 2).sum()
+            loss.backward()
+            optim_resume.step()
+            optim_resume.zero_grad()
+        save_checkpoint(model_resume, optim_resume, 2, 'tmp.ckpt')
+
+        # Load and continue for 2 more steps
+        cont_model = SimpleModel()
+        cont_optim = torch.optim.SGD(cont_model.parameters(), lr=0.1)
+        step = load_checkpoint(cont_model, cont_optim, 'tmp.ckpt')
+        self.assertEqual(step, 2)
+        for _ in range(2,4):
+            loss = (cont_model() ** 2).sum()
+            loss.backward()
+            cont_optim.step()
+            cont_optim.zero_grad()
+
+        os.remove('tmp.ckpt')
+        self.assertTrue(torch.allclose(model_full.w, cont_model.w))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/training_utils.py
+++ b/training_utils.py
@@ -1,0 +1,34 @@
+import torch
+import math
+
+
+def cosine_lr_wd(step: int, total_steps: int, base_lr: float, base_wd: float, warmup_ratio: float = 0.03):
+    """Return learning rate and weight decay for ``step`` using cosine schedule."""
+    if total_steps <= 0:
+        raise ValueError("total_steps must be positive")
+    warmup_steps = int(total_steps * warmup_ratio)
+    if step < warmup_steps:
+        lr = base_lr * step / max(1, warmup_steps)
+        wd = base_wd
+    else:
+        progress = (step - warmup_steps) / max(1, total_steps - warmup_steps)
+        lr = base_lr * 0.5 * (1 + math.cos(math.pi * progress))
+        wd = base_wd * (1 - progress)
+    return lr, max(wd, 0.0)
+
+
+def save_checkpoint(model: torch.nn.Module, optimizer: torch.optim.Optimizer, step: int, path: str) -> None:
+    """Save model and optimizer state along with current step."""
+    torch.save({
+        "model": model.state_dict(),
+        "optim": optimizer.state_dict(),
+        "step": step,
+    }, path)
+
+
+def load_checkpoint(model: torch.nn.Module, optimizer: torch.optim.Optimizer, path: str) -> int:
+    """Load states from ``path`` and return stored step."""
+    ckpt = torch.load(path, map_location="cpu")
+    model.load_state_dict(ckpt["model"])
+    optimizer.load_state_dict(ckpt["optim"])
+    return int(ckpt.get("step", 0))


### PR DESCRIPTION
## Summary
- implement reusable `cosine_lr_wd` scheduler and checkpoint helpers
- integrate schedules and periodic checkpointing into training scripts
- add resume support with CLI args
- update checkpoint unit test and add new test covering resume behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d44259b08324aa25b2cfdaf31265