### PR TITLE
Add quantized tensor packing utilities

### DIFF
--- a/quantization_utils.py
+++ b/quantization_utils.py
@@ -132,26 +132,24 @@ def unpack_ternary(packed: torch.ByteTensor, shape) -> torch.Tensor:
     out = digits.view(-1)[: int(np.prod(shape))].to(torch.int8) - 1
     return out.view(shape)
 
-#def pack_quantized_tensor(quantized_tensor: torch.Tensor):
-#    padded_length = (quantized_tensor.numel() + 4) // 5 * 5
-#    padded_tensor = torch.full((padded_length,), -1, dtype=torch.int8)
-#    padded_tensor[:quantized_tensor.numel()] = quantized_tensor.reshape(-1)
-#    reshaped_tensor = padded_tensor.view(-1, 5)
-#
-#    unsigned_tensor = reshaped_tensor + 1
-#    packed_data = torch.zeros(reshaped_tensor.size(0), dtype=torch.uint8)
-#    shifts = torch.arange(0, 10, 2, dtype=torch.uint8)
-#    for i in range(5):
-#        packed_data |= unsigned_tensor[:, i] << shifts[i]
-#
-#    return packed_data
 
-#def unpack_quantized_tensor(packed_data: torch.Tensor, original_shape):
-#    unpacked_data = torch.zeros(packed_data.size(0), 5, dtype=torch.int8)
-#    shifts = torch.arange(0, 10, 2, dtype=torch.uint8)
-#    for i in range(5):
-#        unpacked_data[:, i] = (packed_data >> shifts[i]) & 3
-#
-#    ternary_tensor = unpacked_data - 1
-#    original_numel = np.prod(original_shape)
-#    return ternary_tensor.view(-1)[:original_numel].view(original_shape)
+def pack_quantized_tensor(t: torch.Tensor):
+    """Pack a quantized int8 tensor and return the packed data with shape."""
+
+    if t.dtype != torch.int8:
+        raise TypeError("pack_quantized_tensor expects int8 input")
+
+    packed = pack_ternary(t)
+    shape = torch.tensor(t.shape, dtype=torch.int32)
+    return packed, shape
+
+
+def unpack_quantized_tensor(packed: torch.ByteTensor, shape: torch.Tensor) -> torch.Tensor:
+    """Unpack data produced by :func:`pack_quantized_tensor`."""
+
+    if packed.dtype != torch.uint8:
+        raise TypeError("unpack_quantized_tensor expects uint8 data")
+    if shape.dtype not in (torch.int32, torch.int64):
+        raise TypeError("shape tensor must be int32 or int64")
+
+    return unpack_ternary(packed, tuple(shape.tolist()))

--- a/tests/test_pack_utils.py
+++ b/tests/test_pack_utils.py
@@ -1,0 +1,75 @@
+import os
+import json
+import shutil
+import tempfile
+import torch
+import unittest
+
+from quantization_utils import pack_quantized_tensor, unpack_quantized_tensor, quantize_tensor
+import llama_model
+
+class DummyTokenizer:
+    @classmethod
+    def from_pretrained(cls, name):
+        return cls()
+    def save_pretrained(self, path):
+        with open(os.path.join(path, 'tokenizer.json'), 'w') as f:
+            json.dump({}, f)
+
+class DummyConfig:
+    def __init__(self, **kwargs):
+        self.vocab_size = 8
+        self.hidden_size = 4
+        self.num_hidden_layers = 1
+        self.num_attention_heads = 1
+        self.intermediate_size = 4
+        self.pretraining_tp = 1
+        self.max_position_embeddings = 8
+        self.layer_norm_eps = 1e-5
+        self.bos_token_id = None
+        self.eos_token_id = None
+        self.__dict__.update(kwargs)
+    @classmethod
+    def from_pretrained(cls, path):
+        with open(os.path.join(path, 'config.json'), 'r') as f:
+            return cls(**json.load(f))
+    def save_pretrained(self, path):
+        with open(os.path.join(path, 'config.json'), 'w') as f:
+            json.dump(self.__dict__, f)
+
+class PackUtilsTest(unittest.TestCase):
+    def test_pack_unpack_roundtrip(self):
+        torch.manual_seed(0)
+        t = torch.randint(-1, 2, (10, 7), dtype=torch.int8)
+        packed, shape = pack_quantized_tensor(t)
+        out = unpack_quantized_tensor(packed, shape)
+        self.assertTrue(torch.equal(t, out))
+
+    def test_model_save_load_roundtrip(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            orig_LlamaConfig = llama_model.LlamaConfig
+            orig_Tokenizer = llama_model.AutoTokenizer
+            orig_save_file = llama_model.save_file
+            orig_load_file = llama_model.load_file
+            llama_model.LlamaConfig = DummyConfig
+            llama_model.AutoTokenizer = DummyTokenizer
+            llama_model.save_file = torch.save
+            llama_model.load_file = torch.load
+
+            config = DummyConfig()
+            model = llama_model.LlamaModel(config)
+            model.save_pretrained(tmp)
+            loaded = llama_model.LlamaModel.load_pretrained(tmp)
+            for name, param in model.state_dict().items():
+                q = quantize_tensor(param)
+                self.assertTrue(torch.equal(loaded.state_dict()[name], q.float()))
+        finally:
+            shutil.rmtree(tmp)
+            llama_model.LlamaConfig = orig_LlamaConfig
+            llama_model.AutoTokenizer = orig_Tokenizer
+            llama_model.save_file = orig_save_file
+            llama_model.load_file = orig_load_file
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `pack_quantized_tensor` and `unpack_quantized_tensor` based on ternary packing
- use the packing when saving and loading weights
- test packing helpers and save/load roundtrip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855d7b681bc8324bccac6a970bd0149