### PR TITLE
Enable CLI options for evaluation self-correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ python evaluation.py --dataset qa.jsonl --ce_model ce_model --grpo_model grpo_mo
 Passing `--two_layer` runs a second correction pass before scoring each answer.
 The correction concatenates the query, the first answer and the text from
 `--guiding_prompt` (default "Review and correct the answer:") before generating
-the final response.
+the final response.  Customize the prompt with `--guiding_prompt` and use
+`--second_max_length` to control how many tokens are generated for the
+correction.
 
 ## Inference
 

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -7,6 +7,7 @@ TRANS_AVAILABLE = importlib.util.find_spec("transformers") is not None
 if TRANS_AVAILABLE:
     import inference
     import data_loading_compatibility as dlc
+    import evaluation
 
 
 @unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
@@ -23,6 +24,27 @@ class DataLoadingCLITest(unittest.TestCase):
         with mock.patch('data_loading_compatibility.run') as run:
             dlc.main(['--model_path', 'm', '--text', 'hi'])
             run.assert_called_with('m', 'hi', max_length=100)
+
+
+@unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
+class EvaluationCLITest(unittest.TestCase):
+    def test_main_calls_run(self):
+        with mock.patch('evaluation.run') as run:
+            evaluation.main([
+                '--dataset', 'd.json',
+                '--ce_model', 'ce',
+                '--grpo_model', 'grpo',
+            ])
+            run.assert_called_with(
+                'd.json',
+                'ce',
+                'grpo',
+                max_length=20,
+                task='qa',
+                two_layer=False,
+                guiding_prompt='Review and correct the answer:',
+                second_max_length=20,
+            )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- expose `get_arg_parser`, `run`, and `main(argv)` in `evaluation.py`
- add CLI test for evaluation script
- document the new options in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855de6c868c8324b694929b8722b2d5