### PR TITLE
Implement quantized model I/O helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ Passing `--e` enables an experimental quantisation mode.
 python new-model-architecture-creation.py --params 750M --output_dir llama_750M
 ```
 
+## Quantized Model Format
+
+`LlamaModel.save_pretrained` writes quantised weights to `model.safetensors`.
+Each tensor from the model `state_dict` is saved with a `model.` prefix and a
+matching `<name>.shape` entry holding the original dimensions.  The accompanying
+`model.safetensors.index.json` lists the tensor names and includes a
+`metadata.total_size` field giving the total byte size.  Config and tokenizer
+files are stored alongside these.
+
 ## Cross‑Entropy Training
 
 `trainingv2.py` performs standard CE training on tokenised text datasets.  The

--- a/quantized_model_io.py
+++ b/quantized_model_io.py
@@ -1,0 +1,70 @@
+import os
+import json
+import torch
+
+try:
+    from safetensors.torch import save_file, load_file
+except Exception:  # pragma: no cover - optional dependency
+    save_file = load_file = None  # type: ignore[misc]
+
+from quantization_utils import quantize_tensor, pack_quantized_tensor, unpack_quantized_tensor
+
+
+def quantize_state_dict(state_dict: dict[str, torch.Tensor]):
+    """Quantise a model ``state_dict`` using ternary packing.
+
+    Returns the packed tensors, a weight map and metadata containing the total
+    byte size.
+    """
+    quantized: dict[str, torch.Tensor] = {}
+    weight_map: dict[str, str] = {}
+    total_size = 0
+
+    for name, param in state_dict.items():
+        if not isinstance(param, torch.Tensor):
+            continue
+        q = quantize_tensor(param)
+        packed, shape = pack_quantized_tensor(q)
+        quantized[name] = packed
+        quantized[name + ".shape"] = shape
+        size = packed.numel() * packed.element_size() + shape.numel() * shape.element_size()
+        total_size += size
+        weight_map[name] = "model.safetensors"
+        weight_map[name + ".shape"] = "model.safetensors"
+
+    metadata = {"total_size": total_size}
+    return quantized, weight_map, metadata
+
+
+def save_quantized_model(model: torch.nn.Module, save_directory: str) -> None:
+    """Save ``model`` weights quantised to ternary format at ``save_directory``."""
+    if save_file is None:
+        raise ImportError("safetensors is required to save quantized models")
+
+    os.makedirs(save_directory, exist_ok=True)
+    state_dict = {f"model.{k}": v for k, v in model.state_dict().items()}
+    qsd, weight_map, meta = quantize_state_dict(state_dict)
+
+    with open(os.path.join(save_directory, "model.safetensors.index.json"), "w") as f:
+        json.dump({"metadata": meta, "weight_map": weight_map}, f, indent=2)
+
+    save_file(qsd, os.path.join(save_directory, "model.safetensors"))
+
+
+def load_quantized_model(model: torch.nn.Module, model_path: str) -> None:
+    """Load ternary quantised weights from ``model_path`` into ``model``."""
+    if load_file is None:
+        raise ImportError("safetensors is required to load quantized models")
+
+    sd = load_file(os.path.join(model_path, "model.safetensors"))
+    out: dict[str, torch.Tensor] = {}
+    for key, value in sd.items():
+        if key.endswith(".shape"):
+            continue
+        shape_key = key + ".shape"
+        if shape_key in sd:
+            value = unpack_quantized_tensor(value, sd[shape_key])
+        out[key.replace("model.", "")] = value
+
+    model.load_state_dict(out)
+

--- a/tests/test_pack_utils.py
+++ b/tests/test_pack_utils.py
@@ -52,10 +52,15 @@ class PackUtilsTest(unittest.TestCase):
             orig_Tokenizer = llama_model.AutoTokenizer
             orig_save_file = llama_model.save_file
             orig_load_file = llama_model.load_file
+            import quantized_model_io as qio
+            orig_qsave = qio.save_file
+            orig_qload = qio.load_file
             llama_model.LlamaConfig = DummyConfig
             llama_model.AutoTokenizer = DummyTokenizer
             llama_model.save_file = torch.save
             llama_model.load_file = torch.load
+            qio.save_file = torch.save
+            qio.load_file = torch.load
 
             config = DummyConfig()
             model = llama_model.LlamaModel(config)
@@ -70,6 +75,8 @@ class PackUtilsTest(unittest.TestCase):
             llama_model.AutoTokenizer = orig_Tokenizer
             llama_model.save_file = orig_save_file
             llama_model.load_file = orig_load_file
+            qio.save_file = orig_qsave
+            qio.load_file = orig_qload
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_quantized_model_io.py
+++ b/tests/test_quantized_model_io.py
@@ -1,0 +1,38 @@
+import os
+import shutil
+import tempfile
+import torch
+import unittest
+
+import quantized_model_io as qio
+from quantization_utils import quantize_tensor
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.lin = torch.nn.Linear(4, 3)
+
+class QuantizedIOTest(unittest.TestCase):
+    def test_save_load_roundtrip(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            orig_save = qio.save_file
+            orig_load = qio.load_file
+            qio.save_file = torch.save
+            qio.load_file = torch.load
+
+            model = DummyModel()
+            qio.save_quantized_model(model, tmp)
+            loaded = DummyModel()
+            qio.load_quantized_model(loaded, tmp)
+
+            for name, param in model.state_dict().items():
+                q = quantize_tensor(param)
+                self.assertTrue(torch.equal(loaded.state_dict()[name], q.float()))
+        finally:
+            shutil.rmtree(tmp)
+            qio.save_file = orig_save
+            qio.load_file = orig_load
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `quantized_model_io.py` with helper functions to save and load packed models
- refactor `LlamaModel` to use the helper functions
- update `inference.py` to use `LlamaModel.load_pretrained`
- document quantised model format
- update and extend tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e8c29918832489da3eb7f55ec49b