### PR TITLE
Add example scripts for training and evaluation

### DIFF
--- a/scripts/ce_training.sh
+++ b/scripts/ce_training.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Example CE training using default hyperparameters on a text dataset.
+# Replace DATA_PATH with the path to your dataset and MODEL_PATH with the base model.
+DATA_PATH="data/train.jsonl"
+MODEL_PATH="llama_750m"
+OUTPUT_DIR="ce_model"
+python trainingv2.py \
+    --dataset "$DATA_PATH" \
+    --model_path "$MODEL_PATH" \
+    --output_dir "$OUTPUT_DIR" \
+    --iters 10000 \
+    --batch_size 8

--- a/scripts/evaluate.py
+++ b/scripts/evaluate.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Run evaluation on the official reasoning datasets and print a table."""
+import pandas as pd
+from evaluation import run
+
+CE_MODEL = "ce_model"      # path to CE model
+GRPO_MODEL = "grpo_model"  # path to GRPO model
+
+def main():
+    datasets = ["math", "gsm8k", "minerva", "olympiadbench"]
+    rows = []
+    for name in datasets:
+        metrics = run(name, CE_MODEL, GRPO_MODEL, task="reasoning", two_layer=True)
+        m = metrics["grpo"]
+        rows.append({
+            "Dataset": name,
+            "Acc.@t1": m["accuracy_t1"],
+            "Acc.@t2": m["accuracy_t2"],
+            "Delta_i->c": m["delta_i2c"],
+            "Delta_c->i": m["delta_c2i"],
+        })
+    df = pd.DataFrame(rows)
+    df["Acc.@t1"] *= 100
+    df["Acc.@t2"] *= 100
+    df["Delta_i->c"] *= 100
+    df["Delta_c->i"] *= 100
+    print(df.to_string(index=False, formatters={col: lambda x: f"{x:.1f}" for col in df.columns[1:]}))
+
+if __name__ == "__main__":
+    main()

--- a/scripts/grpo_training.sh
+++ b/scripts/grpo_training.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Example GRPO training with default hyperparameters on a QA dataset.
+# Replace DATA_PATH, MODEL_PATH and REWARD_MODEL as needed.
+DATA_PATH="qa.jsonl"
+MODEL_PATH="llama_750m"
+REWARD_MODEL="rm.ckpt"  # path to RewardModel checkpoint
+OUTPUT_DIR="grpo_model"
+python grpo_train.py \
+    --dataset "$DATA_PATH" \
+    --model_path "$MODEL_PATH" \
+    --reward_model "$REWARD_MODEL" \
+    --output_dir "$OUTPUT_DIR" \
+    --steps 1000


### PR DESCRIPTION
## Summary
- add helper shell scripts for CE and GRPO training
- add Python script to compute evaluation table for reasoning datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6855f74806148324bb04cc7353732541