### PR TITLE
Add support for multiple guiding prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ Example `config.json` providing defaults:
 }
 ```
 `guiding_prompt` can be either the prompt text itself or a path to a file
-containing the text.
+containing one or more prompts. When multiple prompts are provided one is chosen
+at random for each correction step.
 
 ### GRPO Hyperparameters
 
@@ -137,6 +138,8 @@ Passing `--two_layer` enables a second GRPO pass that attempts to refine the fir
 ```bash
 python grpo_train.py --dataset qa.jsonl --model_path llama_750m --reward_model rm.ckpt --output_dir grpo_model --two_layer --guiding_prompt "Review and correct the answer:"
 ```
+`--guiding_prompt` also accepts a path to a text or JSON file containing multiple
+prompts. One of these prompts will be chosen at random for each correction.
 
 ## Evaluation
 
@@ -151,7 +154,9 @@ python evaluation.py --dataset qa.jsonl --ce_model ce_model --grpo_model grpo_mo
 Passing `--two_layer` runs a second correction pass before scoring each answer.
 The correction concatenates the query, the first answer and the text from
 `--guiding_prompt` (default "Review and correct the answer:") before generating
-the final response.  Customize the prompt with `--guiding_prompt` and use
+the final response.  `--guiding_prompt` may point to a file with several prompts;
+one will be chosen randomly for every correction.  Customize the prompt with
+`--guiding_prompt` and use
 `--second_max_length` to control how many tokens are generated for the
 correction.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -13,12 +13,12 @@ class ConfigTest(unittest.TestCase):
         update_args_with_config(args, parser)
         self.assertEqual(args.lr, 0.5)
         self.assertEqual(args.group_size, 4)
-        self.assertEqual(args.guiding_prompt, "check")
+        self.assertEqual(args.guiding_prompt, ["check"])
         args = parser.parse_args(["--dataset", "d.json", "--model_path", "m", "--config", "tmp_cfg.json", "--lr", "0.1"])
         update_args_with_config(args, parser)
         self.assertEqual(args.lr, 0.1)
         self.assertEqual(args.group_size, 4)
-        self.assertEqual(args.guiding_prompt, "check")
+        self.assertEqual(args.guiding_prompt, ["check"])
 
     def test_guiding_prompt_file(self):
         parser = get_arg_parser()
@@ -29,6 +29,17 @@ class ConfigTest(unittest.TestCase):
             json.dump(cfg, f)
         args = parser.parse_args(["--dataset", "d.json", "--model_path", "m", "--config", "tmp_cfg2.json"])
         update_args_with_config(args, parser)
-        self.assertEqual(args.guiding_prompt, "file prompt")
+        self.assertEqual(args.guiding_prompt, ["file prompt"])
+
+    def test_guiding_prompt_list_file(self):
+        parser = get_arg_parser()
+        with open("prompts.txt", "w", encoding="utf-8") as f:
+            f.write("one\ntwo\n")
+        cfg = {"guiding_prompt": "prompts.txt"}
+        with open("tmp_cfg3.json", "w", encoding="utf-8") as f:
+            json.dump(cfg, f)
+        args = parser.parse_args(["--dataset", "d.json", "--model_path", "m", "--config", "tmp_cfg3.json"])
+        update_args_with_config(args, parser)
+        self.assertEqual(args.guiding_prompt, ["one", "two"])
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- allow a list of guiding prompts in `MultiLayerGRPOTrainer`
- randomly select one prompt for each second-layer correction
- load prompts from JSON or newline text files in `grpo_train.py`
- document multiple prompt usage in README
- update config handling and add unit tests for random prompt selection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68560163696883248f037f11d2be7031