### PR TITLE
Fix quantisation size accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ python new-model-architecture-creation.py --params 750M --output_dir llama_750M
 Each tensor from the model `state_dict` is saved with a `model.` prefix and a
 matching `<name>.shape` entry holding the original dimensions.  The accompanying
 `model.safetensors.index.json` lists the tensor names and includes a
-`metadata.total_size` field giving the total byte size.  Config and tokenizer
-files are stored alongside these.
+`metadata.total_size` field giving the total byte size.  The byte count is
+calculated using `numel * 1.58 / 8` for each tensor, with a small overhead for
+the stored shape. Config and tokenizer files are stored alongside these.
 
 ## Cross‑Entropy Training
 

--- a/llama_model.py
+++ b/llama_model.py
@@ -449,7 +449,8 @@ class LlamaModel(nn.Module):
             shard_file = f"model-{shard_id:05d}-of-{num_shards:05d}.safetensors"
             for key in state_dict.keys():
                 weight_map[key] = shard_file
-            total_size += sum(v.numel() * v.element_size() for v in state_dict.values())
+            for v in state_dict.values():
+                total_size += math.ceil(v.numel() * 1.58 / 8) + v.dim() * 4
 
         index_data = {
             "metadata": {

--- a/quantized_model_io.py
+++ b/quantized_model_io.py
@@ -1,5 +1,6 @@
 import os
 import json
+import math
 import torch
 
 try:
@@ -27,7 +28,9 @@ def quantize_state_dict(state_dict: dict[str, torch.Tensor]):
         packed, shape = pack_quantized_tensor(q)
         quantized[name] = packed
         quantized[name + ".shape"] = shape
-        size = packed.numel() * packed.element_size() + shape.numel() * shape.element_size()
+        # Approximate byte size assuming 1.58 bits per value plus shape overhead
+        numel = param.numel()
+        size = math.ceil(numel * 1.58 / 8) + shape.numel() * shape.element_size()
         total_size += size
         weight_map[name] = "model.safetensors"
         weight_map[name + ".shape"] = "model.safetensors"

--- a/tests/test_size_reporting.py
+++ b/tests/test_size_reporting.py
@@ -1,0 +1,17 @@
+import math
+import torch
+import unittest
+import quantized_model_io as qio
+
+class SizeReportingTest(unittest.TestCase):
+    def test_total_size_estimation(self):
+        model = torch.nn.Linear(4, 3)
+        state = {"model.lin.weight": model.weight, "model.lin.bias": model.bias}
+        qsd, wm, meta = qio.quantize_state_dict(state)
+        expected = 0
+        for t in state.values():
+            expected += math.ceil(t.numel() * 1.58 / 8) + t.dim() * 4
+        self.assertEqual(meta["total_size"], expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- refine size calculations using `numel * 1.58 / 8`
- include shape overhead
- update quantised model utilities and architecture script
- create test for metadata byte size reporting
- document byte size formula

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856122981f48324b459fb407691f1cf