### PR TITLE
Allow guiding prompt files

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,16 @@ The correction prompt follows the template:
 <user>{query}<think>{first_answer}</think>{guiding_prompt}</user><assistant>
 ```
 
-`--guiding_prompt` may also be a path to a text or JSON file containing multiple prompts. One of these prompts will be chosen at random for each correction.
+`--guiding_prompt` may be a path to a text or JSON file containing multiple
+prompts. One of these prompts is randomly selected for each correction.
 
 ```bash
 python grpo_train.py --dataset qa.jsonl --model_path llama_750m \
     --reward_model rm1.ckpt rm2.ckpt --reward_weights 0.7 0.3 \
-    --output_dir grpo_model --two_layer --guiding_prompt "Review and correct the answer:"
+    --output_dir grpo_model --two_layer --guiding_prompt prompts.txt
 ```
-`--guiding_prompt` also accepts a path to a text or JSON file containing multiple
-prompts. One of these prompts will be chosen at random for each correction.
+Here `prompts.txt` contains one prompt per line (or a JSON list) used for the
+second pass.
 
 ## Evaluation
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,6 +42,21 @@ class ConfigTest(unittest.TestCase):
         update_args_with_config(args, parser)
         self.assertEqual(args.guiding_prompt, ["one", "two"])
 
+    def test_guiding_prompt_cli_file(self):
+        parser = get_arg_parser()
+        with open("cli_prompts.txt", "w", encoding="utf-8") as f:
+            f.write("a\nb\n")
+        args = parser.parse_args([
+            "--dataset",
+            "d.json",
+            "--model_path",
+            "m",
+            "--guiding_prompt",
+            "cli_prompts.txt",
+        ])
+        update_args_with_config(args, parser)
+        self.assertEqual(args.guiding_prompt, ["a", "b"])
+
     def test_multiple_reward_models_cli(self):
         parser = get_arg_parser()
         args = parser.parse_args([


### PR DESCRIPTION
## Summary
- load CLI `--guiding_prompt` from files
- parse guiding prompt in `update_args_with_config`
- show prompt-file usage in README
- test guiding prompt file handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561a9e6aa48324acc100bac37e1619