### PR TITLE
Add reasoning metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,9 @@ second pass.
 
 `evaluation.py` compares a CE fine‑tuned model to a GRPO model using the same QA
 F1 reward as training.  The dataset format matches the GRPO training set
-(`{ "query": ..., "answer": ... }`).
+(`{ "query": ..., "answer": ... }`). When a record includes a `reasoning` field the
+script also reports token level F1 for the text inside `<think>` tags and a
+`step_correctness` metric measuring how many reasoning steps match the reference.
 
 ```bash
 python evaluation.py --dataset qa.jsonl --ce_model ce_model --grpo_model grpo_model

--- a/grpo_data.py
+++ b/grpo_data.py
@@ -40,11 +40,17 @@ def load_qa_dataset(path: str) -> List[Dict[str, str]]:
         with open(path, 'r', encoding='utf-8') as f:
             for line in f:
                 obj = json.loads(line)
-                data.append({'query': obj['query'], 'answer': obj['answer']})
+                rec = {'query': obj['query'], 'answer': obj['answer']}
+                if 'reasoning' in obj:
+                    rec['reasoning'] = obj['reasoning']
+                data.append(rec)
     elif path.endswith('.json'):
         with open(path, 'r', encoding='utf-8') as f:
             for obj in json.load(f):
-                data.append({'query': obj['query'], 'answer': obj['answer']})
+                rec = {'query': obj['query'], 'answer': obj['answer']}
+                if 'reasoning' in obj:
+                    rec['reasoning'] = obj['reasoning']
+                data.append(rec)
     else:
         raise ValueError('Unsupported dataset format')
     return data

--- a/tests/data/reasoning_dataset.json
+++ b/tests/data/reasoning_dataset.json
@@ -1,0 +1,4 @@
+[
+  {"query": "Q1", "reasoning": "step one. step two.", "answer": "42"},
+  {"query": "Q2", "reasoning": "first step; second step", "answer": "yes"}
+]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -114,5 +114,21 @@ class ReasoningEvalTest(unittest.TestCase):
         self.assertAlmostEqual(metrics["accuracy_t2"], 1.0)
         self.assertAlmostEqual(metrics["delta_i2c"], 1.0)
 
+    def test_reasoning_scores(self):
+        data = [{"query": "a", "answer": "42", "reasoning": "xy"}]
+        class Tok(DummyTokenizer):
+            _map = {'a':2,'x':4,'y':5,'4':6,'2':7}
+            _rev = {v:k for k,v in _map.items()}
+        tok = Tok()
+
+        class Model(torch.nn.Module):
+            def generate(self, inp, max_length, do_sample=False):
+                out = tok.encode("<think>xy</think>42")
+                return torch.tensor([inp[0].tolist() + out])
+
+        metrics = evaluate_reasoning_model(Model(), tok, data, 4)
+        self.assertAlmostEqual(metrics["reasoning_token_f1"], 1.0)
+        self.assertAlmostEqual(metrics["step_correctness"], 1.0)
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_reasoning_dataset.py
+++ b/tests/test_reasoning_dataset.py
@@ -1,0 +1,11 @@
+import unittest
+from grpo_data import load_qa_dataset
+
+class ReasoningDatasetTest(unittest.TestCase):
+    def test_load_reasoning(self):
+        data = load_qa_dataset('tests/data/reasoning_dataset.json')
+        self.assertIn('reasoning', data[0])
+        self.assertEqual(data[0]['reasoning'], 'step one. step two.')
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_reward_utils.py
+++ b/tests/test_reward_utils.py
@@ -1,5 +1,10 @@
 import unittest
-from reward_utils import qa_reward, _WN_AVAILABLE
+from reward_utils import (
+    qa_reward,
+    _WN_AVAILABLE,
+    reasoning_token_f1,
+    step_correctness,
+)
 
 
 class RewardUtilsTest(unittest.TestCase):
@@ -21,6 +26,16 @@ class RewardUtilsTest(unittest.TestCase):
 
     def test_stemming(self):
         self.assertAlmostEqual(qa_reward("running", "run"), 1.0)
+
+    def test_reasoning_token_f1(self):
+        pred = "<think>step one</think>42"
+        ref_reason = "step one"
+        self.assertAlmostEqual(reasoning_token_f1(pred, ref_reason), 1.0)
+
+    def test_step_correctness(self):
+        pred = "<think>step one. step two</think>42"
+        ref = "step one. step two"
+        self.assertAlmostEqual(step_correctness(pred, ref), 1.0)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add reasoning extraction & metrics
- calculate reasoning F1 and step correctness in evaluation
- load reasoning text in datasets
- extend tests for new metrics and dataset loading
- document reasoning metrics in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68561d5178fc832483679f0e77999a2f