### PR TITLE
Add checkpoint resume example and script test

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ the stored shape. Config and tokenizer files are stored alongside these.
 
 `trainingv2.py` performs standard CE training on tokenised text datasets.  The
 file may be plain text or a JSON/JSONL file containing a `text` field.  Each
-line or record is treated as one training example.
+line or record is treated as one training example. Pass `--save_interval` to
+periodically checkpoint training and `--resume` to continue from a saved
+checkpoint.
 
 ```bash
 python trainingv2.py --dataset path/to/data.jsonl --model_path path/to/model --output_dir ce_out --iters 1000
@@ -124,7 +126,9 @@ Training large models is memory intensive. The scripts are tested on Apple MPS w
 Example command for a small CE run:
 
 ```bash
-python trainingv2.py --dataset data/train.jsonl --model_path llama_750m --output_dir ce_model --iters 10000 --batch_size 8
+python trainingv2.py --dataset data/train.jsonl --model_path llama_750m \
+    --output_dir ce_model --iters 10000 --batch_size 8 \
+    --resume ce_model/ce.ckpt --save_interval 1000
 ```
 
 Example command for GRPO with two reward models:

--- a/scripts/ce_training.sh
+++ b/scripts/ce_training.sh
@@ -4,9 +4,22 @@
 DATA_PATH="data/train.jsonl"
 MODEL_PATH="llama_750m"
 OUTPUT_DIR="ce_model"
+CKPT="$OUTPUT_DIR/ce.ckpt"
 python trainingv2.py \
     --dataset "$DATA_PATH" \
     --model_path "$MODEL_PATH" \
     --output_dir "$OUTPUT_DIR" \
     --iters 10000 \
-    --batch_size 8
+    --batch_size 8 \
+    --resume "$CKPT" \
+    --save_interval 1000
+
+# To resume training after interruption run the same command again:
+# python trainingv2.py \
+#     --dataset "$DATA_PATH" \
+#     --model_path "$MODEL_PATH" \
+#     --output_dir "$OUTPUT_DIR" \
+#     --iters 10000 \
+#     --batch_size 8 \
+#     --resume "$CKPT" \
+#     --save_interval 1000

--- a/tests/test_trainingv2_script.py
+++ b/tests/test_trainingv2_script.py
@@ -1,0 +1,112 @@
+import os
+import shutil
+import tempfile
+import unittest
+import torch
+from unittest import mock
+
+
+class DummyTokenizer:
+    pad_token_id = 0
+    eos_token_id = 1
+    vocab_size = 10
+
+    @classmethod
+    def from_pretrained(cls, path):
+        return cls()
+
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) % 5 + 2 for c in text]
+
+class DummyConfig:
+    def __init__(self, **kwargs):
+        self.vocab_size = 10
+        self.hidden_size = 4
+        self.num_hidden_layers = 1
+        self.num_attention_heads = 1
+        self.intermediate_size = 4
+        self.pretraining_tp = 1
+        self.max_position_embeddings = 8
+        self.__dict__.update(kwargs)
+
+    @classmethod
+    def from_pretrained(cls, path):
+        return cls()
+
+class DummyModel(torch.nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.embed = torch.nn.Embedding(config.vocab_size, config.hidden_size)
+        self.lm_head = torch.nn.Linear(config.hidden_size, config.vocab_size)
+        self.config = config
+
+    def forward(self, x, attention_mask=None, cos=None, sin=None):
+        emb = self.embed(x)
+        return self.lm_head(emb)
+
+    def generate(self, inp, max_length, do_sample=True):
+        B, L = inp.size()
+        gen = torch.zeros(B, max_length - L, dtype=torch.long)
+        return torch.cat([inp, gen], dim=1)
+
+    def save_pretrained(self, path):
+        os.makedirs(path, exist_ok=True)
+
+import sys
+import types
+
+transformers = types.SimpleNamespace(AutoTokenizer=DummyTokenizer, LlamaConfig=DummyConfig)
+sys.modules.setdefault('transformers', transformers)
+sys.modules.setdefault('safetensors.torch', types.SimpleNamespace(load_file=lambda *a, **k: None))
+import trainingv2
+
+class ScriptCheckpointTest(unittest.TestCase):
+    def test_save_and_resume(self):
+        tmp = tempfile.mkdtemp()
+        try:
+            data_path = os.path.join(tmp, "data.jsonl")
+            with open(data_path, "w") as f:
+                f.write('{"text": "ab"}\n{"text": "bc"}\n')
+            ckpt = os.path.join(tmp, "ckpt.pt")
+            parser = trainingv2.get_arg_parser()
+            args = parser.parse_args([
+                '--dataset', data_path,
+                '--model_path', tmp,
+                '--output_dir', tmp,
+                '--iters', '2',
+                '--batch_size', '1',
+                '--resume', ckpt,
+                '--save_interval', '1',
+            ])
+            orig_iter = trainingv2.iterate_batches
+            def _iter_batches(*a, **k):
+                for b in orig_iter(*a, **k):
+                    yield tuple(t.long() for t in b)
+
+            with mock.patch.object(trainingv2, 'LlamaConfig', DummyConfig), \
+                 mock.patch.object(trainingv2, 'AutoTokenizer', DummyTokenizer), \
+                 mock.patch.object(trainingv2, 'LlamaModel', DummyModel), \
+                 mock.patch.object(trainingv2, 'iterate_batches', _iter_batches):
+                trainingv2.run(args)
+            self.assertEqual(torch.load(ckpt)['step'], 2)
+
+            args2 = parser.parse_args([
+                '--dataset', data_path,
+                '--model_path', tmp,
+                '--output_dir', tmp,
+                '--iters', '4',
+                '--batch_size', '1',
+                '--resume', ckpt,
+                '--save_interval', '1',
+            ])
+            with mock.patch.object(trainingv2, 'LlamaConfig', DummyConfig), \
+                 mock.patch.object(trainingv2, 'AutoTokenizer', DummyTokenizer), \
+                 mock.patch.object(trainingv2, 'LlamaModel', DummyModel), \
+                 mock.patch.object(trainingv2, 'iterate_batches', _iter_batches):
+                trainingv2.run(args2)
+            self.assertEqual(torch.load(ckpt)['step'], 4)
+        finally:
+            shutil.rmtree(tmp)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/trainingv2.py
+++ b/trainingv2.py
@@ -187,7 +187,8 @@ def train(model, tokenizer, dataset, batch_size, num_epochs, learning_rate, iter
         save_checkpoint(model, optimizer, iters, resume)
     return model
 
-if __name__ == "__main__":
+def get_arg_parser() -> argparse.ArgumentParser:
+    """Return the command line argument parser for the training script."""
     parser = argparse.ArgumentParser(description="Fine-tuning script.")
     parser.add_argument("--dataset", type=str, help="Path to the dataset file.")
     parser.add_argument("--model_path", type=str, required=True, help="Path to the pre-trained model.")
@@ -204,9 +205,11 @@ if __name__ == "__main__":
     parser.add_argument("--grad_accum_steps", type=int, default=1, help="Number of steps for gradient accumulation.")
     parser.add_argument("--resume", type=str, default=None, help="Checkpoint to resume from")
     parser.add_argument("--save_interval", type=int, default=0, help="Steps between checkpoint saves")
+    return parser
 
-    args = parser.parse_args()
 
+def run(args: argparse.Namespace):
+    """Execute training based on ``args`` from :func:`get_arg_parser`."""
     file_format = args.dataset.split(".")[-1]
     dataset = preprocess_dataset(args.dataset, file_format)
 
@@ -244,3 +247,14 @@ if __name__ == "__main__":
         save_interval=args.save_interval,
     )
     model.save_pretrained(args.output_dir)
+    return model
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = get_arg_parser()
+    args = parser.parse_args(argv)
+    run(args)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- support calling trainingv2 from tests with a parser and run() function
- checkpoint periodically and resume in ce_training.sh
- document resume and save_interval usage in README
- test checkpoint save/resume via trainingv2 script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68562385caf08324abd55f5c7cf4153a