### PR TITLE
Add augmentation_size model update test

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,5 @@ pytest
 ```
 
 All tests should pass; one test is skipped when WordNet data is unavailable.
+Recent tests also verify that `MultiLayerGRPOTrainer` handles `--augmentation_size`
+values greater than one by generating multiple corrections and updating the model.


### PR DESCRIPTION
## Summary
- extend GRPO trainer tests to cover `augmentation_size>1`
- confirm that extra corrections are produced and model parameters update
- document the new check in README

## Testing
- `pytest tests/test_mgrpo.py -q`
- `pytest -q tests/test_mgrpo.py::GRPOTest::test_augmentation_size_updates_model -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f56b2f748324bf0bc15683a7f671