### PR TITLE
Add improvement threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ parameters which mirror the publication are:
 - `beta` – weight applied to the KL penalty against the reference policy.
 - `verifier` – optional function used in the second layer to decide if a
   correction is considered an improvement.
+- `improvement_threshold` – reward margin required for a correction to count as
+  an improvement when the final answer is not exactly correct.
 - The second GRPO layer trains on corrected answers whose reward improves over
   the first pass, using the reward difference as the advantage.
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,5 +73,31 @@ class ConfigTest(unittest.TestCase):
         ])
         self.assertEqual(args.reward_model, ["a.pt", "b.pt"])
         self.assertEqual(args.reward_weights, [0.4, 0.6])
+
+    def test_improvement_threshold(self):
+        parser = get_arg_parser()
+        cfg = {"improvement_threshold": 0.2}
+        with open("cfg_thr.json", "w", encoding="utf-8") as f:
+            json.dump(cfg, f)
+        args = parser.parse_args([
+            "--dataset",
+            "d.json",
+            "--model_path",
+            "m",
+            "--config",
+            "cfg_thr.json",
+        ])
+        update_args_with_config(args, parser)
+        self.assertEqual(args.improvement_threshold, 0.2)
+        args = parser.parse_args([
+            "--dataset",
+            "d.json",
+            "--model_path",
+            "m",
+            "--improvement_threshold",
+            "0.1",
+        ])
+        update_args_with_config(args, parser)
+        self.assertEqual(args.improvement_threshold, 0.1)
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- improve `simple_improvement_verifier` to support final-answer checks
- expose `--improvement_threshold` to control the verifier
- update `MultiLayerGRPOTrainer` to pass text and references to the verifier
- document new option in README
- expand config tests for the new argument

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859f7f988288324a0adeaf0264131f2