### PR TITLE
Enable correction buffer in MultiLayerGRPOTrainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,6 @@ pytest
 All tests should pass; one test is skipped when WordNet data is unavailable.
 Recent tests also verify that `MultiLayerGRPOTrainer` handles `--augmentation_size`
 values greater than one by generating multiple corrections and updating the model.
+Successful second-pass corrections are kept in a buffer so that future calls to
+`MultiLayerGRPOTrainer.train_batch` can reinforce them alongside newly generated
+samples.


### PR DESCRIPTION
## Summary
- support persistent correction buffer so successful second-pass outputs are reused
- document new behaviour in README
- test buffer reuse and clear buffer when checking deterministic behaviour

## Testing
- `pytest tests/test_mgrpo.py -q`

------
https://chatgpt.com/codex/tasks/task_e_685a00dd61008324ab70086fe0654802