### PR TITLE
Enable weighted rule-based rewards in GRPO

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,10 +70,11 @@ dataset should be JSON or JSONL with one object per record:
 {"query": "...", "answer": "..."}
 ```
 
-During training candidate answers are generated for each query and scored. If
-one or more `--reward_model` checkpoints are provided the scores from each model
-are combined (optionally weighted with `--reward_weights`) to approximate dense
-feedback. Without a reward model the robust F1 reward from `qa_reward` is used.
+During training candidate answers are generated for each query and scored.  The
+robust F1 reward from `qa_reward` can be mixed with one or more
+`--reward_model` checkpoints.  Model scores are combined (optionally weighted
+with `--reward_weights`) then interpolated with the rule-based reward using
+`--rule_weight`.  When no reward model is supplied, only the F1 reward is used.
 
 Optional features:
 
@@ -87,6 +88,8 @@ Optional features:
   answers for inspection.
 - `--resume CKPT` &ndash; resume training from a checkpoint created with
   `save_checkpoint`.
+- `--rule_weight` &ndash; weight assigned to the rule-based F1 reward when
+  combining with external reward models.
 - `--guiding_probabilities` &ndash; probabilities corresponding to each entry in
   `--guiding_prompt` for weighted random selection.
 - `--guiding_schedule` &ndash; sequence of prompt indices determining which
@@ -145,7 +148,7 @@ Example command for GRPO with two reward models:
 
 ```bash
 python grpo_train.py --dataset qa.jsonl --model_path llama_750m \
-    --reward_model rm1.ckpt rm2.ckpt --reward_weights 0.7 0.3 \
+    --reward_model rm1.ckpt rm2.ckpt --reward_weights 0.7 0.3 --rule_weight 0.5 \
     --output_dir grpo_model
 ```
 
@@ -165,7 +168,7 @@ prompts. By default a prompt is chosen at random for each correction. Pass
 
 ```bash
 python grpo_train.py --dataset qa.jsonl --model_path llama_750m \
-    --reward_model rm1.ckpt rm2.ckpt --reward_weights 0.7 0.3 \
+    --reward_model rm1.ckpt rm2.ckpt --reward_weights 0.7 0.3 --rule_weight 0.5 \
     --output_dir grpo_model --two_layer --guiding_prompt prompts.txt
 ```
 Here `prompts.txt` contains one prompt per line (or a JSON list) used for the

--- a/grpo.py
+++ b/grpo.py
@@ -226,7 +226,12 @@ class MultiLayerGRPOTrainer:
                         )
                     new_resp = gen[0, inp_len:]
                     text = self.tokenizer.decode(new_resp.tolist())
-                    reward_val = float(self.reward_fn(text))
+                    query_text = self.tokenizer.decode(q_tokens.tolist())
+                    ref_text = references[b] if references is not None else None
+                    try:
+                        reward_val = float(self.reward_fn(text, ref_text, query_text))
+                    except TypeError:
+                        reward_val = float(self.reward_fn(text))
                     if self.verifier is None:
                         improved = reward_val > base_reward
                     else:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -70,13 +70,16 @@ class ConfigTest(unittest.TestCase):
             "--reward_weights",
             "0.4",
             "0.6",
+            "--rule_weight",
+            "0.3",
         ])
         self.assertEqual(args.reward_model, ["a.pt", "b.pt"])
         self.assertEqual(args.reward_weights, [0.4, 0.6])
+        self.assertAlmostEqual(args.rule_weight, 0.3)
 
     def test_improvement_threshold(self):
         parser = get_arg_parser()
-        cfg = {"improvement_threshold": 0.2}
+        cfg = {"improvement_threshold": 0.2, "rule_weight": 0.7}
         with open("cfg_thr.json", "w", encoding="utf-8") as f:
             json.dump(cfg, f)
         args = parser.parse_args([
@@ -89,6 +92,7 @@ class ConfigTest(unittest.TestCase):
         ])
         update_args_with_config(args, parser)
         self.assertEqual(args.improvement_threshold, 0.2)
+        self.assertAlmostEqual(args.rule_weight, 0.7)
         args = parser.parse_args([
             "--dataset",
             "d.json",


### PR DESCRIPTION
## Summary
- update GRPO trainer to handle reward functions expecting query and reference
- allow `grpo_train.py` to interpolate QA F1 with weighted reward models
- expose `--rule_weight` argument and document its usage
- extend configuration tests for new option

## Testing
- `pip install -q -r requirements.txt` *(fails: no output)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a0a1de42c8324ac3a2f4f7adf4bb2