### PR TITLE
Add accuracy_t1_prime metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ F1 reward as training.  The dataset format matches the GRPO training set
 (`{ "query": ..., "answer": ... }`). When a record includes a `reasoning` field the
 script also reports token level F1 for the text inside `<think>` tags and a
 `step_correctness` metric measuring how many reasoning steps match the reference.
+When using the two layer mode additional statistics are printed, including
+`accuracy_t1_prime` (accuracy after the second pass prior to RL updates) and
+`delta_t1p_t2` showing the change from this baseline to the final accuracy.
 
 ```bash
 python evaluation.py --dataset qa.jsonl --ce_model ce_model --grpo_model grpo_model

--- a/evaluation.py
+++ b/evaluation.py
@@ -80,6 +80,7 @@ def evaluate_reasoning_model(
 
     correct_first = 0
     correct_second = 0
+    correct_second_prime = 0
     changed_ic = 0
     changed_ci = 0
     tok_f1_sum = 0.0
@@ -116,6 +117,7 @@ def evaluate_reasoning_model(
         else:
             final_text = first_text
         second_ok = bool(accuracy_reward(final_text, sample["answer"]))
+        second_prime_ok = second_ok if two_layer else first_ok
         ref_reasoning = sample.get("reasoning")
         if ref_reasoning is not None:
             from reward_utils import reasoning_token_f1, step_correctness
@@ -124,6 +126,7 @@ def evaluate_reasoning_model(
 
         correct_first += first_ok
         correct_second += second_ok
+        correct_second_prime += second_prime_ok
         if not first_ok and second_ok:
             changed_ic += 1
         if first_ok and not second_ok:
@@ -132,7 +135,9 @@ def evaluate_reasoning_model(
     N = len(dataset)
     metrics = {
         "accuracy_t1": correct_first / N,
+        "accuracy_t1_prime": correct_second_prime / N,
         "accuracy_t2": correct_second / N,
+        "delta_t1p_t2": (correct_second / N) - (correct_second_prime / N),
         "delta_i2c": changed_ic / N,
         "delta_c2i": changed_ci / N,
     }

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -89,6 +89,8 @@ class ReasoningEvalTest(unittest.TestCase):
 
         metrics = evaluate_reasoning_model(Model(), tok, data, 2)
         self.assertAlmostEqual(metrics["accuracy_t1"], 1.0)
+        self.assertAlmostEqual(metrics["accuracy_t1_prime"], 1.0)
+        self.assertAlmostEqual(metrics["delta_t1p_t2"], 0.0)
         self.assertAlmostEqual(metrics["delta_i2c"], 0.0)
 
     def test_two_layer_metrics(self):
@@ -111,7 +113,9 @@ class ReasoningEvalTest(unittest.TestCase):
             Model(), tok, data, 1, two_layer=True, guiding_prompt="a", second_max_length=1
         )
         self.assertAlmostEqual(metrics["accuracy_t1"], 0.0)
+        self.assertAlmostEqual(metrics["accuracy_t1_prime"], 1.0)
         self.assertAlmostEqual(metrics["accuracy_t2"], 1.0)
+        self.assertAlmostEqual(metrics["delta_t1p_t2"], 0.0)
         self.assertAlmostEqual(metrics["delta_i2c"], 1.0)
 
     def test_reasoning_scores(self):


### PR DESCRIPTION
## Summary
- extend reasoning model evaluator with accuracy_t1_prime and delta_t1p_t2
- document new metrics in README
- update unit tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'transformers')*

------
https://chatgpt.com/codex/tasks/task_e_685a100a091c83248f00c6fa668f661c