### PR TITLE
Add HBitLinear packed layer to LlamaModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This repository provides an implementation of the 1.58 BitNet LLaMA model. The project aims to reduce memory usage through ternary quantisation while keeping the training workflow close to standard LLaMA models.
 
+### Packed Hadamard Linear Layers
+
+The code includes an `HBitLinear` module implementing a Hadamard transform with
+packed 1.58‑bit weights. `LlamaModel` uses this layer by default.  To fall back
+to the older quantised `BitLinear` simply pass `linear_cls=BitLinear` when
+instantiating or loading a model.
+
 ## Requirements and Setup
 
 The code depends on a handful of well‑known libraries.  A

--- a/tests/test_pack_utils.py
+++ b/tests/test_pack_utils.py
@@ -67,8 +67,12 @@ class PackUtilsTest(unittest.TestCase):
             model.save_pretrained(tmp)
             loaded = llama_model.LlamaModel.load_pretrained(tmp)
             for name, param in model.state_dict().items():
-                q = quantize_tensor(param)
-                self.assertTrue(torch.equal(loaded.state_dict()[name], q.float()))
+                loaded_param = loaded.state_dict()[name]
+                if torch.is_floating_point(param) and param.numel() > 1:
+                    q = quantize_tensor(param)
+                    self.assertTrue(torch.equal(loaded_param, q.float()))
+                else:
+                    self.assertTrue(torch.equal(loaded_param, param))
         finally:
             shutil.rmtree(tmp)
             llama_model.LlamaConfig = orig_LlamaConfig

--- a/tests/test_quantized_model_io.py
+++ b/tests/test_quantized_model_io.py
@@ -27,8 +27,12 @@ class QuantizedIOTest(unittest.TestCase):
             qio.load_quantized_model(loaded, tmp)
 
             for name, param in model.state_dict().items():
-                q = quantize_tensor(param)
-                self.assertTrue(torch.equal(loaded.state_dict()[name], q.float()))
+                loaded_param = loaded.state_dict()[name]
+                if torch.is_floating_point(param) and param.numel() > 1:
+                    q = quantize_tensor(param)
+                    self.assertTrue(torch.equal(loaded_param, q.float()))
+                else:
+                    self.assertTrue(torch.equal(loaded_param, param))
         finally:
             shutil.rmtree(tmp)
             qio.save_file = orig_save


### PR DESCRIPTION
## Summary
- integrate `HBitLinear` as the default linear layer
- support packed weights in quantized model I/O
- update tests for packed weights
- document the new layer in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a173d98e88324a7752e5e6faec271