### PR TITLE
Add evaluation table output

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,11 +195,18 @@ script also reports token level F1 for the text inside `<think>` tags and a
 `step_correctness` metric measuring how many reasoning steps match the reference.
 When using the two layer mode additional statistics are printed, including
 `accuracy_t1_prime` (accuracy after the second pass prior to RL updates) and
-`delta_t1p_t2` showing the change from this baseline to the final accuracy.
+`delta_t1p_t2` showing the change from this baseline to the final accuracy. A
+`delta_t1_t2` metric is also reported measuring the accuracy improvement from
+the first to second pass.
 
 ```bash
 python evaluation.py --dataset qa.jsonl --ce_model ce_model --grpo_model grpo_model
 ```
+
+When both models are evaluated on a reasoning dataset the script prints a table
+mirroring Table 2 in the paper summarising `accuracy_t1`, `accuracy_t1_prime`,
+`accuracy_t2`, `delta_t1_t2`, `delta_t1p_t2`, `delta_i2c` and `delta_c2i` for
+each model.
 
 Passing `--two_layer` runs a second correction pass before scoring each answer.
 The second pass uses the same template as training with `<think>` tags.  The

--- a/evaluation.py
+++ b/evaluation.py
@@ -137,6 +137,7 @@ def evaluate_reasoning_model(
         "accuracy_t1": correct_first / N,
         "accuracy_t1_prime": correct_second_prime / N,
         "accuracy_t2": correct_second / N,
+        "delta_t1_t2": (correct_second / N) - (correct_first / N),
         "delta_t1p_t2": (correct_second / N) - (correct_second_prime / N),
         "delta_i2c": changed_ic / N,
         "delta_c2i": changed_ci / N,
@@ -252,12 +253,24 @@ def run(
         guiding_prompt=guiding_prompt,
         second_max_length=second_max_length,
     )
-    print("CE model metrics:")
-    for k, v in ce_metrics.items():
-        print(f"  {k}: {v:.4f}")
-    print("GRPO model metrics:")
-    for k, v in grpo_metrics.items():
-        print(f"  {k}: {v:.4f}")
+    metrics_to_show = [
+        "accuracy_t1",
+        "accuracy_t1_prime",
+        "accuracy_t2",
+        "delta_t1_t2",
+        "delta_t1p_t2",
+        "delta_i2c",
+        "delta_c2i",
+    ]
+    header = f"{'Metric':<18}{'CE model':>12}{'GRPO model':>12}"
+    print(header)
+    print("-" * len(header))
+    for key in metrics_to_show:
+        ce_val = ce_metrics.get(key)
+        grpo_val = grpo_metrics.get(key)
+        ce_str = f"{ce_val:.4f}" if ce_val is not None else "-"
+        grpo_str = f"{grpo_val:.4f}" if grpo_val is not None else "-"
+        print(f"{key:<18}{ce_str:>12}{grpo_str:>12}")
     return {"ce": ce_metrics, "grpo": grpo_metrics}
 
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -90,6 +90,7 @@ class ReasoningEvalTest(unittest.TestCase):
         metrics = evaluate_reasoning_model(Model(), tok, data, 2)
         self.assertAlmostEqual(metrics["accuracy_t1"], 1.0)
         self.assertAlmostEqual(metrics["accuracy_t1_prime"], 1.0)
+        self.assertAlmostEqual(metrics["delta_t1_t2"], 0.0)
         self.assertAlmostEqual(metrics["delta_t1p_t2"], 0.0)
         self.assertAlmostEqual(metrics["delta_i2c"], 0.0)
 
@@ -115,6 +116,7 @@ class ReasoningEvalTest(unittest.TestCase):
         self.assertAlmostEqual(metrics["accuracy_t1"], 0.0)
         self.assertAlmostEqual(metrics["accuracy_t1_prime"], 1.0)
         self.assertAlmostEqual(metrics["accuracy_t2"], 1.0)
+        self.assertAlmostEqual(metrics["delta_t1_t2"], 1.0)
         self.assertAlmostEqual(metrics["delta_t1p_t2"], 0.0)
         self.assertAlmostEqual(metrics["delta_i2c"], 1.0)
 


### PR DESCRIPTION
## Summary
- calculate `delta_t1_t2` when evaluating reasoning models
- display CE and GRPO metrics in a table
- document the new output and metric in the README
- adjust unit tests for the new metric

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a1d6128e88324acbfac1978b4d1a9