### PR TITLE
Add MGRPO benchmark scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,27 @@ python grpo_train.py --dataset qa.jsonl --model_path llama_750m \
 Here `prompts.txt` contains one prompt per line (or a JSON list) used for the
 second pass.
 
+## MGRPO Benchmark Scripts
+
+The `scripts` directory contains helpers for running multi‑layer GRPO on the
+official reasoning benchmarks. Each wrapper downloads the dataset and launches
+`grpo_train.py` with the paper hyperparameters from `scripts/paper_config.json`.
+
+```bash
+# Train on the MATH benchmark
+scripts/mgrpo_math.sh
+
+# Train on GSM8K
+scripts/mgrpo_gsm8k.sh
+
+# Train on Minerva Math
+scripts/mgrpo_minerva.sh
+
+# Train on OlympiadBench
+scripts/mgrpo_olympiadbench.sh
+```
+Edit the reward model path inside each script to point at your checkpoint.
+
 ## Evaluation
 
 `evaluation.py` compares a CE fine‑tuned model to a GRPO model using the same QA

--- a/scripts/mgrpo_gsm8k.sh
+++ b/scripts/mgrpo_gsm8k.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run MGRPO on the GSM8K dataset using paper hyperparameters.
+MODEL_PATH="llama_750m"
+REWARD_MODEL="rm.ckpt"
+OUTPUT_DIR="mgrpo_gsm8k"
+python scripts/run_mgrpo_reasoning.py gsm8k \
+    --model_path "$MODEL_PATH" \
+    --reward_model "$REWARD_MODEL" \
+    --output_dir "$OUTPUT_DIR"

--- a/scripts/mgrpo_math.sh
+++ b/scripts/mgrpo_math.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run MGRPO on the MATH benchmark using paper hyperparameters.
+MODEL_PATH="llama_750m"
+REWARD_MODEL="rm.ckpt"
+OUTPUT_DIR="mgrpo_math"
+python scripts/run_mgrpo_reasoning.py math \
+    --model_path "$MODEL_PATH" \
+    --reward_model "$REWARD_MODEL" \
+    --output_dir "$OUTPUT_DIR"

--- a/scripts/mgrpo_minerva.sh
+++ b/scripts/mgrpo_minerva.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run MGRPO on the Minerva Math dataset using paper hyperparameters.
+MODEL_PATH="llama_750m"
+REWARD_MODEL="rm.ckpt"
+OUTPUT_DIR="mgrpo_minerva"
+python scripts/run_mgrpo_reasoning.py minerva \
+    --model_path "$MODEL_PATH" \
+    --reward_model "$REWARD_MODEL" \
+    --output_dir "$OUTPUT_DIR"

--- a/scripts/mgrpo_olympiadbench.sh
+++ b/scripts/mgrpo_olympiadbench.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Run MGRPO on the OlympiadBench dataset using paper hyperparameters.
+MODEL_PATH="llama_750m"
+REWARD_MODEL="rm.ckpt"
+OUTPUT_DIR="mgrpo_olympiad"
+python scripts/run_mgrpo_reasoning.py olympiadbench \
+    --model_path "$MODEL_PATH" \
+    --reward_model "$REWARD_MODEL" \
+    --output_dir "$OUTPUT_DIR"

--- a/scripts/run_mgrpo_reasoning.py
+++ b/scripts/run_mgrpo_reasoning.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Run Multi-layer GRPO on reasoning benchmarks.
+
+This wrapper loads the selected dataset, writes a temporary JSONL file in the
+format expected by ``grpo_train.py`` and launches training with the hyper-
+parameters from ``scripts/paper_config.json``.
+"""
+import argparse
+import json
+import subprocess
+import tempfile
+from grpo_data import (
+    load_math_dataset,
+    load_gsm8k_dataset,
+    load_minerva_math_dataset,
+    load_olympiadbench_dataset,
+)
+
+DATASET_LOADERS = {
+    "math": load_math_dataset,
+    "gsm8k": load_gsm8k_dataset,
+    "minerva": load_minerva_math_dataset,
+    "olympiadbench": load_olympiadbench_dataset,
+}
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Run MGRPO on a reasoning benchmark")
+    parser.add_argument(
+        "dataset", choices=DATASET_LOADERS.keys(), help="Benchmark to train on"
+    )
+    parser.add_argument("--model_path", default="llama_750m", help="Pretrained model")
+    parser.add_argument("--reward_model", required=True, help="RewardModel checkpoint")
+    parser.add_argument("--output_dir", default="mgrpo_model", help="Directory for the trained model")
+    parser.add_argument(
+        "--config",
+        default="scripts/paper_config.json",
+        help="JSON config with hyperparameters",
+    )
+    parser.add_argument(
+        "--guiding_prompt",
+        default="Review and correct the answer:",
+        help="Prompt used during the second pass",
+    )
+    args = parser.parse_args(argv)
+
+    data = DATASET_LOADERS[args.dataset]()
+    with tempfile.NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:
+        for rec in data:
+            json.dump({"query": rec["query"], "answer": rec["answer"]}, f)
+            f.write("\n")
+        dataset_path = f.name
+
+    cmd = [
+        "python",
+        "grpo_train.py",
+        "--dataset",
+        dataset_path,
+        "--model_path",
+        args.model_path,
+        "--reward_model",
+        args.reward_model,
+        "--output_dir",
+        args.output_dir,
+        "--two_layer",
+        "--guiding_prompt",
+        args.guiding_prompt,
+        "--config",
+        args.config,
+    ]
+    subprocess.run(cmd, check=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `run_mgrpo_reasoning.py` wrapper to launch multi-layer GRPO on benchmarks
- add convenience shell scripts for MATH, GSM8K, Minerva Math and OlympiadBench
- document benchmark scripts in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac8706fcc8324895e1e6eb3d4b9f9