### PR TITLE
Add intrinsic self‑correction baseline utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,20 @@ Helper loader functions such as `load_math_dataset` rely on the
 `datasets` library. They now accept an optional `path` argument for
 loading a local copy instead of downloading from the Hugging Face hub.
 If a dataset cannot be loaded a readable `RuntimeError` is raised.
+### Intrinsic Self-Correction Baseline
+
+Use `intrinsic_baseline.py` to measure a model's ability to correct its own answers without any RL updates. The script performs a second pass with a guiding prompt and reports the same metrics as `evaluation.py`.
+
+```bash
+python intrinsic_baseline.py --dataset qa.jsonl --model ce_model
+```
+
+For reasoning datasets pass `--task reasoning`:
+
+```bash
+python intrinsic_baseline.py --dataset math --model ce_model --task reasoning
+```
+
 
 ## Inference
 

--- a/intrinsic_baseline.py
+++ b/intrinsic_baseline.py
@@ -1,0 +1,121 @@
+import argparse
+from transformers import AutoTokenizer
+from llama_model import LlamaModel
+from grpo_data import (
+    load_qa_dataset,
+    load_math_dataset,
+    load_gsm8k_dataset,
+    load_minerva_math_dataset,
+    load_olympiadbench_dataset,
+)
+from evaluation import evaluate_model, evaluate_reasoning_model
+
+
+def load_dataset(name: str):
+    name_l = name.lower()
+    if name_l == "math":
+        return load_math_dataset()
+    if name_l == "gsm8k":
+        return load_gsm8k_dataset()
+    if name_l == "minerva":
+        return load_minerva_math_dataset()
+    if name_l == "olympiadbench":
+        return load_olympiadbench_dataset()
+    return load_qa_dataset(name)
+
+
+def get_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Evaluate the intrinsic self-correction baseline",
+    )
+    parser.add_argument("--dataset", type=str, required=True)
+    parser.add_argument("--model", type=str, required=True)
+    parser.add_argument(
+        "--task",
+        choices=["qa", "reasoning"],
+        default="qa",
+        help="Dataset type: 'qa' uses F1 reward, 'reasoning' uses accuracy",
+    )
+    parser.add_argument("--max_length", type=int, default=20)
+    parser.add_argument(
+        "--guiding_prompt",
+        type=str,
+        default="Review and correct the answer:",
+        help="Prompt appended during the second pass",
+    )
+    parser.add_argument(
+        "--second_max_length",
+        type=int,
+        default=20,
+        help="Tokens to generate for the correction",
+    )
+    return parser
+
+
+def run(
+    dataset: str,
+    model: str,
+    *,
+    task: str = "qa",
+    max_length: int = 20,
+    guiding_prompt: str = "Review and correct the answer:",
+    second_max_length: int = 20,
+) -> dict:
+    data = load_dataset(dataset)
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    model_obj = LlamaModel.load_pretrained(model)
+    if task == "qa":
+        score = evaluate_model(
+            model_obj,
+            tokenizer,
+            data,
+            max_length,
+            two_layer=True,
+            guiding_prompt=guiding_prompt,
+            second_max_length=second_max_length,
+        )
+        print(f"Intrinsic self-correction F1: {score:.4f}")
+        return {"f1": score}
+    metrics = evaluate_reasoning_model(
+        model_obj,
+        tokenizer,
+        data,
+        max_length,
+        two_layer=True,
+        guiding_prompt=guiding_prompt,
+        second_max_length=second_max_length,
+    )
+    metrics_to_show = [
+        "accuracy_t1",
+        "accuracy_t1_prime",
+        "accuracy_t2",
+        "delta_t1_t2",
+        "delta_t1p_t2",
+        "delta_i2c",
+        "delta_c2i",
+    ]
+    header = f"{'Metric':<18}{'Value':>12}"
+    print(header)
+    print("-" * len(header))
+    for key in metrics_to_show:
+        val = metrics.get(key)
+        val_str = f"{val:.4f}" if val is not None else "-"
+        print(f"{key:<18}{val_str:>12}")
+    return metrics
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = get_arg_parser()
+    args = parser.parse_args(argv)
+    run(
+        args.dataset,
+        args.model,
+        task=args.task,
+        max_length=args.max_length,
+        guiding_prompt=args.guiding_prompt,
+        second_max_length=args.second_max_length,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -8,6 +8,7 @@ if TRANS_AVAILABLE:
     import inference
     import data_loading_compatibility as dlc
     import evaluation
+    import intrinsic_baseline
 
 
 @unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
@@ -42,6 +43,24 @@ class EvaluationCLITest(unittest.TestCase):
                 max_length=20,
                 task='qa',
                 two_layer=False,
+                guiding_prompt='Review and correct the answer:',
+                second_max_length=20,
+            )
+
+
+@unittest.skipUnless(TRANS_AVAILABLE, "transformers not available")
+class IntrinsicBaselineCLITest(unittest.TestCase):
+    def test_main_calls_run(self):
+        with mock.patch('intrinsic_baseline.run') as run:
+            intrinsic_baseline.main([
+                '--dataset', 'd.json',
+                '--model', 'm',
+            ])
+            run.assert_called_with(
+                'd.json',
+                'm',
+                task='qa',
+                max_length=20,
                 guiding_prompt='Review and correct the answer:',
                 second_max_length=20,
             )


### PR DESCRIPTION
## Summary
- implement `intrinsic_baseline.py` for the self-correction baseline
- update README with baseline instructions
- test CLI invocation of the new script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685acf1d523c832480052c479c0323db