### PR TITLE
Add dense reward support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Optional features:
   to save memory.
 - `--rule_weight` &ndash; weight assigned to the rule-based F1 reward when
   combining with external reward models.
+- Reward models now support **dense** scoring. When available the training
+  loop consumes a sequence of per-token rewards instead of a single scalar.
 - `--guiding_probabilities` &ndash; probabilities corresponding to each entry in
   `--guiding_prompt` for weighted random selection.
 - `--guiding_schedule` &ndash; sequence of prompt indices determining which

--- a/tests/test_mgrpo.py
+++ b/tests/test_mgrpo.py
@@ -55,6 +55,18 @@ class GRPOTest(unittest.TestCase):
         loss = trainer.step(queries, responses, lengths, rewards, optim)
         self.assertIsInstance(loss.item(), float)
 
+    def test_dense_rewards(self):
+        model = DummyModel()
+        ref = DummyModel()
+        trainer = GRPOTrainer(model, ref)
+        optim = torch.optim.SGD(model.parameters(), lr=0.01)
+        queries = torch.randint(0, 10, (1, 3))
+        responses = torch.randint(0, 10, (1, 1, 4))
+        lengths = torch.tensor([[4]])
+        rewards = torch.rand(1, 1, 4)
+        loss = trainer.step(queries, responses, lengths, rewards, optim)
+        self.assertIsInstance(loss.item(), float)
+
     def test_multilayer(self):
         model = DummyModel()
         ref = DummyModel()

--- a/tests/test_reward_model.py
+++ b/tests/test_reward_model.py
@@ -16,6 +16,13 @@ class RewardModelTest(unittest.TestCase):
         val = model.score("hi", "there")
         self.assertIsInstance(val, float)
 
+    def test_dense_score(self):
+        tok = DummyTokenizer()
+        model = RewardModel(vocab_size=tok.vocab_size, tokenizer=tok)
+        seq = model.score("hi", "abc", dense=True)
+        self.assertEqual(seq.numel(), 3)
+        self.assertIsInstance(seq, torch.Tensor)
+
     def test_load_reward_models_weighted_sum(self):
         tok = DummyTokenizer()
 

--- a/tests/test_reward_utils.py
+++ b/tests/test_reward_utils.py
@@ -1,9 +1,13 @@
 import unittest
+import torch
+from unittest import mock
+import reward_utils
 from reward_utils import (
     qa_reward,
     _WN_AVAILABLE,
     reasoning_token_f1,
     step_correctness,
+    RewardModelScorer,
 )
 
 
@@ -36,6 +40,39 @@ class RewardUtilsTest(unittest.TestCase):
         pred = "<think>step one. step two</think>42"
         ref = "step one. step two"
         self.assertAlmostEqual(step_correctness(pred, ref), 1.0)
+
+    def test_reward_model_scorer_dense(self):
+        class DummyTok:
+            sep_token_id = 0
+
+            def __call__(self, q, r, return_tensors=None):
+                ids = list(range(1, len(q) + 1)) + [0] + list(range(1, len(r) + 1))
+                return {"input_ids": torch.tensor([ids])}
+
+            def encode(self, text, add_special_tokens=False):
+                return list(range(len(text)))
+
+        class DummyOut:
+            def __init__(self, logits):
+                self.logits = logits
+
+        class DummyModel:
+            def eval(self):
+                pass
+
+            def __call__(self, **kwargs):
+                L = kwargs["input_ids"].size(1)
+                logits = torch.arange(1, L + 1, dtype=torch.float).view(1, L, 1)
+                return DummyOut(logits)
+
+        with mock.patch.object(reward_utils, "AutoTokenizer", create=True) as at:
+            with mock.patch.object(reward_utils, "AutoModelForSequenceClassification", create=True) as am:
+                at.from_pretrained.return_value = DummyTok()
+                am.from_pretrained.return_value = DummyModel()
+                scorer = RewardModelScorer("dummy")
+                dense = scorer.score("a", "bc", dense=True)
+                self.assertEqual(dense.numel(), 2)
+                self.assertLess(dense[0], dense[1])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend reward model with optional dense per-token scoring
- compute dense rewards in `RewardModelScorer`
- allow GRPO trainers to consume dense reward sequences
- document dense reward option
- test dense scoring paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b0093f79c832496510fe2cc4c9b28