### PR TITLE
Add packed low-bit matrix multiply kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ packed 1.58‑bit weights. `LlamaModel` uses this layer by default.  To fall bac
 to the older quantised `BitLinear` simply pass `linear_cls=BitLinear` when
 instantiating or loading a model.
 
+`gemm_lowbit` now supports multiplying int8 activations with these packed
+weights directly via CUDA and MPS kernels. Pass the packed tensor and its
+original shape to perform the multiplication without unpacking.
+
 ## Requirements and Setup
 
 The code depends on a handful of well‑known libraries.  A

--- a/quantized_model_io.py
+++ b/quantized_model_io.py
@@ -31,6 +31,13 @@ def quantize_state_dict(state_dict: dict[str, torch.Tensor]):
             weight_map[name] = "model.safetensors"
             continue
 
+        if param.dtype in (torch.int32, torch.int64):
+            quantized[name] = param
+            size = param.numel() * param.element_size()
+            total_size += size
+            weight_map[name] = "model.safetensors"
+            continue
+
         if param.dtype == torch.int8:
             packed, shape = pack_quantized_tensor(param)
         else:

--- a/tests/test_lowbit_kernel.py
+++ b/tests/test_lowbit_kernel.py
@@ -1,6 +1,6 @@
 import unittest
 import torch
-from quantization_utils import gemm_lowbit
+from quantization_utils import gemm_lowbit, pack_ternary
 
 class LowBitKernelTest(unittest.TestCase):
     def test_matches_matmul(self):
@@ -10,6 +10,29 @@ class LowBitKernelTest(unittest.TestCase):
         out = gemm_lowbit(x, w)
         ref = (x.to(torch.float32) @ w.to(torch.float32).t())
         self.assertTrue(torch.equal(out, ref))
+
+    def test_packed_matches_unpacked(self):
+        torch.manual_seed(0)
+        x = torch.randint(-8, 8, (6, 5), dtype=torch.int8)
+        w = torch.randint(-1, 2, (4, 5), dtype=torch.int8)
+        packed = pack_ternary(w)
+        out_packed = gemm_lowbit(x, packed, w.shape)
+        out_ref = gemm_lowbit(x, w)
+        self.assertTrue(torch.equal(out_packed, out_ref))
+
+    def test_packed_cuda_mps(self):
+        for device in ("cuda", "mps"):
+            if device == "cuda" and not torch.cuda.is_available():
+                continue
+            if device == "mps" and not torch.backends.mps.is_available():
+                continue
+            torch.manual_seed(0)
+            x = torch.randint(-8, 8, (6, 5), dtype=torch.int8, device=device)
+            w = torch.randint(-1, 2, (4, 5), dtype=torch.int8, device=device)
+            packed = pack_ternary(w)
+            out_packed = gemm_lowbit(x, packed, w.shape)
+            out_ref = gemm_lowbit(x, w)
+            self.assertTrue(torch.equal(out_packed.cpu(), out_ref.cpu()))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- extend gemm_lowbit with CUDA/MPS kernel for packed 1.58‑bit weights
- store weight shape in HBitLinear and use packed multiplication
- keep quantized_model_io from quantising int32 buffers
- test new packed kernels across CPU/CUDA/MPS
- document packed kernel support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b32010db88324aa81d98de8c9bfe0