### PR TITLE
Add evaluation hook for training scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ compute.
 python trainingv2.py --dataset path/to/data.jsonl --model_path path/to/model --output_dir ce_out --iters 1000
 ```
 
+Pass `--run_eval` along with `--eval_dataset` to automatically evaluate the
+new model against the original checkpoint using `evaluation.py`. Metrics are
+printed to the console and can be appended to a CSV file via `--eval_csv`.
+
 ## GRPO Training
 
 `grpo_train.py` implements Grouped Response Policy Optimisation (GRPO).  The
@@ -104,6 +108,8 @@ Optional features:
   to save memory.
 - `--rule_weight` &ndash; weight assigned to the rule-based F1 reward when
   combining with external reward models.
+- `--run_eval` &ndash; evaluate the final model using `evaluation.py` after
+  training. Requires `--eval_dataset` and optionally `--eval_csv`.
 - Reward models now support **dense** scoring. When available the training
   loop consumes a sequence of per-token rewards instead of a single scalar.
 - `--guiding_probabilities` &ndash; probabilities corresponding to each entry in
@@ -150,6 +156,10 @@ averaged over tokens.
 python grpo_train.py --config scripts/paper_config.json --dataset qa.jsonl \
     --model_path path/to/model --output_dir grpo_out --csv_log metrics.csv
 ```
+
+Include `--run_eval` with an evaluation dataset to score the resulting model
+immediately after training. Use `--eval_csv` to append these metrics to a log
+file.
 
 ## Hardware and Example Commands
 

--- a/tests/test_cli_scripts.py
+++ b/tests/test_cli_scripts.py
@@ -45,6 +45,7 @@ class EvaluationCLITest(unittest.TestCase):
                 two_layer=False,
                 guiding_prompt='Review and correct the answer:',
                 second_max_length=20,
+                csv_log=None,
             )
 
 

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,5 +1,9 @@
 import unittest
 import torch
+import os
+import csv
+import tempfile
+import evaluation
 from evaluation import evaluate_model, evaluate_reasoning_model
 from grpo_data import construct_second_pass_input
 
@@ -135,6 +139,18 @@ class ReasoningEvalTest(unittest.TestCase):
         metrics = evaluate_reasoning_model(Model(), tok, data, 4)
         self.assertAlmostEqual(metrics["reasoning_token_f1"], 1.0)
         self.assertAlmostEqual(metrics["step_correctness"], 1.0)
+
+
+class CSVLogTest(unittest.TestCase):
+    def test_log_csv(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "log.csv")
+            evaluation._log_csv({"a": 0.5, "b": 1.0}, path)
+            with open(path, newline="") as f:
+                rows = list(csv.DictReader(f))
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["a"], "0.5")
+            self.assertEqual(rows[0]["b"], "1.0")
 
 if __name__ == '__main__':
     unittest.main()

--- a/trainingv2.py
+++ b/trainingv2.py
@@ -6,6 +6,7 @@ from datasets import load_dataset
 from transformers import AutoTokenizer, LlamaConfig
 from safetensors.torch import load_file
 from llama_model import LlamaModel
+import evaluation
 from training_utils import save_checkpoint, load_checkpoint, cosine_lr_wd
 from custom_gradient_checkpointing import custom_checkpoint
 from tqdm import tqdm
@@ -234,6 +235,41 @@ def get_arg_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Wrap forward pass with custom_checkpoint to save memory",
     )
+    parser.add_argument(
+        "--run_eval",
+        action="store_true",
+        help="Run evaluation.py after training",
+    )
+    parser.add_argument(
+        "--eval_dataset",
+        type=str,
+        default=None,
+        help="Dataset for post-training evaluation",
+    )
+    parser.add_argument(
+        "--eval_task",
+        choices=["qa", "reasoning"],
+        default="qa",
+        help="Evaluation dataset type",
+    )
+    parser.add_argument(
+        "--eval_ce_model",
+        type=str,
+        default=None,
+        help="Baseline CE model path (defaults to --model_path)",
+    )
+    parser.add_argument(
+        "--eval_max_length",
+        type=int,
+        default=20,
+        help="Max length for evaluation generation",
+    )
+    parser.add_argument(
+        "--eval_csv",
+        type=str,
+        default=None,
+        help="CSV file to log evaluation metrics",
+    )
     return parser
 
 
@@ -277,6 +313,16 @@ def run(args: argparse.Namespace):
         use_checkpoint=args.grad_checkpoint,
     )
     model.save_pretrained(args.output_dir)
+    if args.run_eval and args.eval_dataset:
+        ce_model = args.eval_ce_model or args.model_path
+        evaluation.run(
+            args.eval_dataset,
+            ce_model,
+            args.output_dir,
+            max_length=args.eval_max_length,
+            task=args.eval_task,
+            csv_log=args.eval_csv,
+        )
     return model
 
 


### PR DESCRIPTION
## Summary
- add CSV logging utility to `evaluation.py`
- support `--csv_log` for evaluation CLI
- add optional post-training evaluation for `grpo_train.py` and `trainingv2.py`
- update documentation for new flags
- test CLI changes and new evaluation hook

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b38d99c988324a60f951cb1a075dd