### PR TITLE
Add contrastive training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,14 @@ python simple_reward_model.py --epochs 100 --lr 0.1
 The demo prints higher scores for correct answers and can be extended to create
 custom reward models for GRPO training.
 
+`reward_train.py` trains the larger Transformer-based `RewardModel`. Provide a
+labelled dataset with `--dataset` or a file of positive/negative pairs with
+`--pairs`:
+
+```bash
+python reward_train.py --pairs pairs.jsonl --tokenizer path/to/tokenizer
+```
+
 ## Energy RL Demo
 
 The repository also includes a small reinforcement learning environment to

--- a/tests/data/contrastive_pairs.jsonl
+++ b/tests/data/contrastive_pairs.jsonl
@@ -1,0 +1,2 @@
+{"query": "hi", "positive": "there", "negative": "wrong"}
+{"query": "bye", "positive": "ok", "negative": "no"}

--- a/tests/test_reward_train.py
+++ b/tests/test_reward_train.py
@@ -1,0 +1,39 @@
+import os
+import unittest
+from unittest import mock
+import torch
+import reward_train
+
+class DummyTokenizer:
+    def encode(self, text, add_special_tokens=False):
+        return [ord(c) % 5 for c in text]
+    vocab_size = 10
+
+class DummyModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.w = torch.nn.Parameter(torch.zeros(1))
+        self.called = 0
+    def contrastive_loss(self, q, p, n):
+        self.called += 1
+        return self.w.sum()
+    def save(self, path):
+        pass
+
+class RewardTrainTest(unittest.TestCase):
+    def test_load_pair_dataset(self):
+        path = os.path.join(os.path.dirname(__file__), 'data', 'contrastive_pairs.jsonl')
+        data = reward_train.load_pair_dataset(path)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(set(data[0].keys()), {'query', 'positive', 'negative'})
+
+    def test_contrastive_training_used(self):
+        path = os.path.join(os.path.dirname(__file__), 'data', 'contrastive_pairs.jsonl')
+        pairs = reward_train.load_pair_dataset(path)
+        tok = DummyTokenizer()
+        model = DummyModel()
+        reward_train.train(model, tok, dataset=None, pairs=pairs, epochs=1, batch_size=1)
+        self.assertGreaterEqual(model.called, 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow reward_train to use positive/negative pairs
- support contrastive loss
- document how to train RewardModel
- test new dataset loader and contrastive path

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b3d72c578832496f9bc249764ee71